### PR TITLE
A4: subclass the new Draft_OrthoArray tool

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -131,7 +131,8 @@ class Assembly4Workbench(Workbench):
                                 "Asm4_importDatum", 
                                 "Asm4_placeDatum", 
                                 "Asm4_updateAssembly",
-                                "Asm4_newLinkArray"]
+                                "Asm4_newLinkArray",
+                                "Asm4_OrthoArray"]
         # commands to appear in the Assembly4 menu 'Assembly'
         self.itemsMenu =      [ "Asm4_newModel",   
                                 "Asm4_newBody", 
@@ -152,6 +153,7 @@ class Assembly4Workbench(Workbench):
                                 "Asm4_placeDatum", 
                                 "Asm4_importDatum", 
                                 "Asm4_newLinkArray",
+                                "Asm4_OrthoArray",
                                 "Asm4_addVariable", 
                                 "Asm4_Animate", 
                                 "Asm4_updateAssembly"]
@@ -170,6 +172,7 @@ class Assembly4Workbench(Workbench):
                                 "Asm4_importDatum", 
                                 "Asm4_placeDatum", 
                                 "Asm4_newLinkArray",
+                                "Asm4_OrthoArray",
                                 "Asm4_addVariable", 
                                 "Asm4_Animate", 
                                 "Asm4_updateAssembly"]

--- a/makeLinkArray.py
+++ b/makeLinkArray.py
@@ -56,7 +56,7 @@ class newLinkArray():
             #    Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(1, 0, 0),
             #                    App.Vector(0, 1, 0), 2, 2, useLink=True, name=text)
             createdArray = Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(10, 0, 0),
-                            App.Vector(0, 1, 0), 2, 1, useLink=True, name=arrayName)
+                            App.Vector(0, 1, 0), 2, 1, use_link=True, name=arrayName)
             model.addObject(createdArray)
             createdArray.recompute()
             model.recompute()

--- a/newLinkArray.py
+++ b/newLinkArray.py
@@ -83,3 +83,74 @@ class newLinkArray():
 
 # add the command to the workbench
 Gui.addCommand('Asm4_newLinkArray', newLinkArray())
+
+
+import draftguitools.gui_circulararray
+import draftguitools.gui_polararray
+import draftguitools.gui_orthoarray
+import draftguitools.gui_arrays
+
+class A4OrthoArray(draftguitools.gui_orthoarray.GuiCommandOrthoArray):
+
+    def __init__(self):
+        super().__init__()
+
+    def IsActive(self):
+        if App.ActiveDocument and self.checkPart():
+            # Only active when an App::Link
+            # or a Fastener from the Fasteners Workbench is selected
+            return True
+        else:
+            return False
+
+    def Activated(self):
+        selectObject = self.checkPart()
+        model = App.ActiveDocument.getObject('Model')
+        # if something valid has been returned:
+        if selectObject:
+            # Now is time to create the array
+            arrayName = 'array_' + selectObject.Name
+            super().Activated()
+
+            # This code is run by the original command.
+            # It needs to be integrated somehow into this newer code.
+            # Essentially, it just provides a new Label to the link array,
+            # and then the Model absorbs it into itself, and it finally
+            # recomputes the model.
+            #
+            # Absorbing into the model could be done manually, by dragging
+            # the newly created array.
+            # Do we really need to rename and absorb into the model
+            # automatically?
+
+            # Gui.doCommand("createdArray = obj")
+            # Gui.doCommand("App.ActiveDocument.getObject('Model').addObject(createdArray)")
+            # Gui.doCommand("createdArray.Label = " + arrayName)
+            # App.ActiveDocument.recompute()
+
+    def checkPart(self):
+        """Check that the selection is an App::Link or Fastener."""
+        selectedObj = None
+        # check that it's an Assembly4 'Model'
+        self.doc = App.activeDocument()
+
+        if (self.doc.getObject('Model')
+                and self.doc.getObject('Model').TypeId == 'App::Part'):
+            if Gui.Selection.getSelection():
+                selection = Gui.Selection.getSelection()[0]
+
+                # Only create arrays of App::Links
+                # and Fasteners from the Fasteners Workbench
+                if selection.TypeId == 'App::Link':
+                    selectedObj = selection
+                else:
+                    for selObj in Gui.Selection.getSelectionEx():
+                        obj = selObj.Object
+                        if (hasattr(obj, 'Proxy')
+                                and isinstance(obj.Proxy, FSBaseObject)):
+                            selectedObj = obj
+
+        return selectedObj
+
+
+Gui.addCommand('Asm4_OrthoArray', A4OrthoArray())

--- a/newLinkArray.py
+++ b/newLinkArray.py
@@ -53,7 +53,7 @@ class newLinkArray():
             #    Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(1, 0, 0),
             #                    App.Vector(0, 1, 0), 2, 2, useLink=True, name=text)
             createdArray = Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(10, 0, 0),
-                            App.Vector(0, 1, 0), 2, 1, useLink=True, name=arrayName)
+                            App.Vector(0, 1, 0), 2, 1, use_link=True, name=arrayName)
             model.addObject(createdArray)
             createdArray.recompute()
             model.recompute()


### PR DESCRIPTION
This showcases how to add the new [Draft_OrthoArray](https://wiki.freecadweb.org/Draft_OrthoArray) tool from the Draft Workbench into Assembly4.

It imports the required modules, and then subclasses the required class, and adds a bit of specific code to only be able to select `App::Link` objects.

The original `Draft_OrthoArray` launches its own task panel interface in order to change the properties of the created array. It is expected that in the future we will be able to show a bit more advanced behavior, that is, previews of the array.

What is missing is specific code that is able to rename the created array, and place it in the `Model` object of Assembly4. To do this, probably `Draft_OrthoArray` needs to be modified to accept a final callback from any subclass.

A very similar process as the one described in this commit could be done to include the `Draft_PolarArray` and `Draft_CircularArray` tools in Assembly4.