### PR TITLE
A4: update link array from Draft

### DIFF
--- a/makeLinkArray.py
+++ b/makeLinkArray.py
@@ -56,7 +56,7 @@ class newLinkArray():
             #    Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(1, 0, 0),
             #                    App.Vector(0, 1, 0), 2, 2, useLink=True, name=text)
             createdArray = Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(10, 0, 0),
-                            App.Vector(0, 1, 0), 2, 1, useLink=True, name=arrayName)
+                            App.Vector(0, 1, 0), 2, 1, use_link=True, name=arrayName)
             model.addObject(createdArray)
             createdArray.recompute()
             model.recompute()

--- a/newLinkArray.py
+++ b/newLinkArray.py
@@ -53,7 +53,7 @@ class newLinkArray():
             #    Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(1, 0, 0),
             #                    App.Vector(0, 1, 0), 2, 2, useLink=True, name=text)
             createdArray = Draft.makeArray(App.ActiveDocument.getObject(selectObject.Name), App.Vector(10, 0, 0),
-                            App.Vector(0, 1, 0), 2, 1, useLink=True, name=arrayName)
+                            App.Vector(0, 1, 0), 2, 1, use_link=True, name=arrayName)
             model.addObject(createdArray)
             createdArray.recompute()
             model.recompute()


### PR DESCRIPTION
In a recent version of Draft v0.19, the link array creation function has the argument `use_link`, instead of `useLink` to comply with Python style guidelines (PEP8).

Besides that, Draft now has more useful array commands, that could be used, for example, Draft_OrthoArray, Draft_PolarArray, and Draft_CircularArray. They can create App::Links as well.