### PR TITLE
Override 3D view click to select linked part entry in tree view

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -105,6 +105,7 @@ class Assembly4Workbench(Workbench):
         import Asm4_Measure        # Measure tool in the Task panel
         import makeBomCmd          # creates the parts list
         import HelpCmd             # shows a basic help window
+        import treeSelectionOverride    # ovveride 3D view click to select assembly entry in the tree view
         
         # create the toolbars and menus, nearly empty, to decide about their position
         self.appendToolbar("Assembly",["Asm4_newModel"])

--- a/InitGui.py
+++ b/InitGui.py
@@ -31,7 +31,7 @@ asm4wb_icons_path = os.path.join( asm4wbPath, 'Resources/icons')
 global main_Assembly4WB_Icon
 main_Assembly4WB_Icon = os.path.join( asm4wb_icons_path , 'Assembly4.svg' )
 
-
+import treeSelectionOverride as selectionOverride
 
 """
     +-----------------------------------------------+
@@ -64,6 +64,7 @@ class dropDownCmdGroup:
 class Assembly4Workbench(Workbench):
 
     global main_Assembly4WB_Icon
+    global selectionOverride
     MenuText = "Assembly 4"
     ToolTip = "Assembly 4 workbench"
     Icon = main_Assembly4WB_Icon
@@ -74,10 +75,12 @@ class Assembly4Workbench(Workbench):
 
     def Activated(self):
         "This function is executed when the workbench is activated"
+        selectionOverride.Activate()
         return
 
     def Deactivated(self):
         "This function is executed when the workbench is deactivated"
+        selectionOverride.Deactivate()
         return 
 
     def GetClassName(self): 
@@ -105,7 +108,6 @@ class Assembly4Workbench(Workbench):
         import Asm4_Measure        # Measure tool in the Task panel
         import makeBomCmd          # creates the parts list
         import HelpCmd             # shows a basic help window
-        import treeSelectionOverride    # ovveride 3D view click to select assembly entry in the tree view
         
         # create the toolbars and menus, nearly empty, to decide about their position
         self.appendToolbar("Assembly",["Asm4_newModel"])

--- a/libAsm4.py
+++ b/libAsm4.py
@@ -113,6 +113,13 @@ def checkModel():
             retval = model
     return retval
 
+def isLinkToPart(obj):
+    if obj.TypeId == 'App::Link' and hasattr(obj.LinkedObject,'isDerivedFrom'):
+        if  obj.LinkedObject.isDerivedFrom('App::Part') or obj.LinkedObject.isDerivedFrom('PartDesign::Body'):
+            return True
+    else:
+        return False
+
 
 # get from the selected datum the corresponding link
 def getLinkAndDatum():
@@ -125,10 +132,9 @@ def getLinkAndDatum():
         for objStr in parentAssembly.getSubObjects():
             # the string ends with a . that must be removed
             obj = App.ActiveDocument.getObject( objStr[0:-1] )
-            if obj.TypeId == 'App::Link' and hasattr(obj.LinkedObject,'isDerivedFrom'):
-                if  obj.LinkedObject.isDerivedFrom('App::Part') or obj.LinkedObject.isDerivedFrom('PartDesign::Body'):
-                    # add it to our tree table if it's a link to an App::Part ...
-                    childrenTable.append( obj )
+            if isLinkToPart(obj):
+                # add it to our tree table if it's a link to an App::Part ...
+                childrenTable.append( obj )
 
         selObj = Gui.Selection.getSelection()[0]
         # a datum is selected
@@ -479,6 +485,4 @@ def splitExpressionDatum( expr ):
     +-----------------------------------------------+
 """
 # is in the FastenersLib.py file
-
-
 

--- a/treeSelectionOverride.py
+++ b/treeSelectionOverride.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# coding: utf-8
+#
+# treeSelectionOverride.py
+#
+# The code tracks the selections made
+
+import FreeCADGui as Gui
+import FreeCAD as App
+import libAsm4 as Asm4
+
+
+class asm4SelObserver:
+    def addSelection(self,doc,obj,sub,pnt):               # Selection object
+        # Since both 3D view clicks and manual tree selection gets into the same callback
+        # we will determine by clicked coordinates, for manual tree selections the coordinates are (0,0,0)
+        if pnt != (0,0,0):
+            # 3D view click
+            # Get list of objects from the top document to the clicked feature
+            objList = App.getDocument(doc).getObject(obj).getSubObjectList(sub)
+            # Look for the link from bottom of the list up to the top document
+            for subObj in reversed(objList):
+                if Asm4.isLinkToPart(subObj):
+                    Gui.Selection.clearSelection()
+                    # TODO: Check why do we have to add '.' at the end to have the selection work
+                    Gui.Selection.addSelection(doc, obj, subObj.Name + '.')
+                    break
+
+# add the listener, 0 forces to resolve the links
+s = asm4SelObserver()
+Gui.Selection.addObserver(s, 0)
+

--- a/treeSelectionOverride.py
+++ b/treeSelectionOverride.py
@@ -22,11 +22,17 @@ class asm4SelObserver:
             for subObj in reversed(objList):
                 if Asm4.isLinkToPart(subObj):
                     Gui.Selection.clearSelection()
-                    # TODO: Check why do we have to add '.' at the end to have the selection work
+                    # Have to add the '.' at the end to distinguish between features and sub-objects
                     Gui.Selection.addSelection(doc, obj, subObj.Name + '.')
                     break
 
-# add the listener, 0 forces to resolve the links
-s = asm4SelObserver()
-Gui.Selection.addObserver(s, 0)
+observer = asm4SelObserver();
 
+def Activate():
+    global observer
+    # add the listener, 0 forces to resolve the links
+    Gui.Selection.addObserver(observer, 0)
+
+def Deactivate():
+    global observer
+    Gui.Selection.removeObserver(observer) 


### PR DESCRIPTION
Override 3D view click to select linked part entry in tree view
instead of selecting the body of the part.
Improves the efficiency of work, the assembly properties are faster accessible.