### PR TITLE
Show/Hide LCS in objects and child objects.

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -105,6 +105,7 @@ class Assembly4Workbench(Workbench):
         import Asm4_Measure        # Measure tool in the Task panel
         import makeBomCmd          # creates the parts list
         import HelpCmd             # shows a basic help window
+        import showHideLcsCmd      # shows/hides all the LCSs
         
         # create the toolbars and menus, nearly empty, to decide about their position
         self.appendToolbar("Assembly",["Asm4_newModel"])
@@ -238,7 +239,10 @@ class Assembly4Workbench(Workbench):
                                 "Asm4_importDatum"   ,
                                 "Asm4_placeDatum"    ,
                                 'Asm4_FSparameters'  ,
-                                'Asm4_placeFastener' ] 
+                                'Asm4_placeFastener' ,
+                                'Separator'          ,
+                                'Asm4_showLcs'       ,
+                                'Asm4_hideLcs']
         # commands to appear in the 'Create' sub-menu in the contextual menu (right-click)
         self.itemsCreateMenu = ["Asm4_newSketch",  
                                 "Asm4_newBody", 

--- a/libAsm4.py
+++ b/libAsm4.py
@@ -39,6 +39,8 @@ partInfo =[     'Description',                  \
                 'SupplierDescription',          \
                 'SupplierReference' ]
 
+containerTypes = [  'App::Part', \
+                    'PartDesign::Body' ]
 
 """
     +-----------------------------------------------+

--- a/libAsm4.py
+++ b/libAsm4.py
@@ -482,3 +482,30 @@ def splitExpressionDatum( expr ):
 
 
 
+"""
+    +-----------------------------------------------+
+    |        Selection Helper functions             |
+    +-----------------------------------------------+
+"""
+def getModelSelected():
+    if App.ActiveDocument.getObject('Model') and App.ActiveDocument.Model.TypeId == 'App::Part':
+        selection = Gui.Selection.getSelection()
+        if len(selection)==1:
+            selObj = selection[0]
+            if selObj.Name == 'Model' and selObj.TypeId == 'App::Part':
+                return selObj
+    return False
+    
+def getSelection():
+    # check that there is an App::Part called 'Model'
+    if App.ActiveDocument.getObject('Model') and App.ActiveDocument.Model.TypeId == 'App::Part':
+        selection = Gui.Selection.getSelection()
+        if len(selection)==1:
+            selObj = selection[0]
+            # it's an App::Link
+            if selObj.isDerivedFrom('App::Link') and selObj.LinkedObject.TypeId in linkedObjTypes:
+                return selObj
+    return None
+
+# type of App::Link target objects we're dealing with
+linkedObjTypes = [ 'App::Part', 'PartDesign::Body' ]

--- a/placeLinkCmd.py
+++ b/placeLinkCmd.py
@@ -14,27 +14,6 @@ from FreeCAD import Console as FCC
 import libAsm4 as Asm4
 
 
-
-"""
-    +-----------------------------------------------+
-    |               Helper functions                |
-    +-----------------------------------------------+
-"""
-def getSelection():
-    # check that there is an App::Part called 'Model'
-    if App.ActiveDocument.getObject('Model') and App.ActiveDocument.Model.TypeId == 'App::Part':
-        if len(Gui.Selection.getSelection())==1:
-            selObj = Gui.Selection.getSelection()[0]
-            # it's an App::Link
-            if selObj.isDerivedFrom('App::Link') and selObj.LinkedObject.TypeId in linkedObjTypes:
-                return selObj
-    return None
-
-
-# type of App::Link target objects we're dealing with
-linkedObjTypes = [ 'App::Part', 'PartDesign::Body' ]
-
-
 # selection view properties overrides
 DrawStyle = 'Solid'
 LineWidth = 3.0
@@ -60,7 +39,7 @@ class placeLinkCmd():
 
     def IsActive(self):
         # We only insert a link into an Asm4  Model
-        if App.ActiveDocument and getSelection():
+        if App.ActiveDocument and Asm4.getSelection():
             return True
         return False
 
@@ -87,7 +66,7 @@ class placeLinkUI():
 
         # check that we have selected an App::Link object
         self.selectedLink = []
-        selection = getSelection()
+        selection = Asm4.getSelection()
         if not selection:
             # This shouldn't happen
             FCC.PrintWarning("This is not an error message you are supposed to see, something went wrong\n")

--- a/showHideLcsCmd.py
+++ b/showHideLcsCmd.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# coding: utf-8
+#
+# showHideLcsCmd.py
+
+import math, re, os
+
+import FreeCADGui as Gui
+import FreeCAD as App
+
+import libAsm4 as Asm4
+
+
+
+"""
+    +-----------------------------------------------+
+    |                  main class                   |
+    +-----------------------------------------------+
+"""
+class showLcsCmd:
+    def __init__(self):
+        super(showLcsCmd,self).__init__()
+
+    def GetResources(self):
+        return {"MenuText": "Show LCS",
+                "ToolTip": "Show LCS of selected part and its children",
+#                "Pixmap" : os.path.join( Asm4.iconPath , 'Asm4_CoordinateSystem.svg')
+                }
+
+    def IsActive(self):
+        # Will handle LCSs only for the Assembly4 model
+        if Asm4.getSelection() or Asm4.getModelSelected():
+            return True
+        return False
+
+    """
+    +-----------------------------------------------+
+    |                 the real stuff                |
+    +-----------------------------------------------+
+    """
+    def Activated(self):
+        model = Asm4.getModelSelected()
+        if model:
+            for objName in model.getSubObjects():
+                ShowChildLCSs(model.getSubObject(objName, 1), True)
+        else:
+            ShowChildLCSs(Asm4.getSelection(), True)
+
+
+class hideLcsCmd:
+    def __init__(self):
+        super(hideLcsCmd,self).__init__()
+
+    def GetResources(self):
+        return {"MenuText": "Hide LCS",
+                "ToolTip": "Hide LCS of selected part and its children",
+#                "Pixmap" : os.path.join( Asm4.iconPath , 'Asm4_CoordinateSystem.svg')
+                }
+
+    def IsActive(self):
+        # Will handle LCSs only for the Assembly4 model
+        if Asm4.getSelection() or Asm4.getModelSelected():
+            return True
+        return False
+
+    """
+    +-----------------------------------------------+
+    |                 the real stuff                |
+    +-----------------------------------------------+
+    """
+    def Activated(self):
+        model = Asm4.getModelSelected()
+        if model:
+            for objName in model.getSubObjects():
+                ShowChildLCSs(model.getSubObject(objName, 1), False)
+        else:
+            ShowChildLCSs(Asm4.getSelection(), False)
+
+
+
+# Show/Hide the LCSs in the provided object and all linked children
+def ShowChildLCSs(obj, show):
+    lcsTypes = ["PartDesign::CoordinateSystem", "PartDesign::Line", "PartDesign::Point", "PartDesign::Plane"]
+
+    if obj.TypeId == 'App::Link':
+        for linkObj in obj.LinkedObject.Document.Objects:
+            ShowChildLCSs(linkObj, show)
+    else:
+        for subObjName in obj.getSubObjects():
+            subObj = obj.getSubObject(subObjName, 1)    # 1 for returning the real object
+            if subObj != None:
+                if subObj.TypeId in lcsTypes:
+                    subObj.Visibility = show
+
+"""
+    +-----------------------------------------------+
+    |       add the command to the workbench        |
+    +-----------------------------------------------+
+"""
+Gui.addCommand( 'Asm4_showLcs', showLcsCmd() )
+Gui.addCommand( 'Asm4_hideLcs', hideLcsCmd() )
+

--- a/showHideLcsCmd.py
+++ b/showHideLcsCmd.py
@@ -80,17 +80,16 @@ class hideLcsCmd:
 
 # Show/Hide the LCSs in the provided object and all linked children
 def ShowChildLCSs(obj, show):
-    lcsTypes = ["PartDesign::CoordinateSystem", "PartDesign::Line", "PartDesign::Point", "PartDesign::Plane"]
-
     if obj.TypeId == 'App::Link':
         for linkObj in obj.LinkedObject.Document.Objects:
             ShowChildLCSs(linkObj, show)
     else:
-        for subObjName in obj.getSubObjects():
-            subObj = obj.getSubObject(subObjName, 1)    # 1 for returning the real object
-            if subObj != None:
-                if subObj.TypeId in lcsTypes:
-                    subObj.Visibility = show
+        if obj.TypeId in Asm4.containerTypes:
+            for subObjName in obj.getSubObjects():
+                subObj = obj.getSubObject(subObjName, 1)    # 1 for returning the real object
+                if subObj != None:
+                    if subObj.TypeId in Asm4.datumTypes:
+                        subObj.Visibility = show
 
 """
     +-----------------------------------------------+

--- a/showHideLcsCmd.py
+++ b/showHideLcsCmd.py
@@ -39,6 +39,10 @@ class showLcsCmd:
     +-----------------------------------------------+
     """
     def Activated(self):
+        global processedLinks
+        # reset processed links cache
+        processedLinks = []
+
         model = Asm4.getModelSelected()
         if model:
             for objName in model.getSubObjects():
@@ -69,6 +73,10 @@ class hideLcsCmd:
     +-----------------------------------------------+
     """
     def Activated(self):
+        global processedLinks
+        # reset processed links cache
+        processedLinks = []
+
         model = Asm4.getModelSelected()
         if model:
             for objName in model.getSubObjects():
@@ -77,10 +85,15 @@ class hideLcsCmd:
             ShowChildLCSs(Asm4.getSelection(), False)
 
 
+# Already processed links cache, no need to process the same part if its linked multiple times
+processedLinks = []
 
 # Show/Hide the LCSs in the provided object and all linked children
 def ShowChildLCSs(obj, show):
-    if obj.TypeId == 'App::Link':
+    global processedLinks
+
+    if obj.TypeId == 'App::Link' and obj.Name not in processedLinks:
+        processedLinks.append(obj.Name)
         for linkObj in obj.LinkedObject.Document.Objects:
             ShowChildLCSs(linkObj, show)
     else:


### PR DESCRIPTION
Please see the code.
Icons are still missing.
Currently accessible from context menu (right-click) when a part is selected on assembly level or the whole "Model" entry in the tree.

It's slow when there are many objects, I don't like the API we have today with the getSubObjects and getSubObject(name) functions that slow down everything related to tree entries, including the pre-selection I think.
Maybe will look on the code later when I have time...
