### PR TITLE
placeLinkCmd: Specify absolute AttachmentOffset (translation and rotation) of linked part, LCS preselection

### DIFF
--- a/libAsm4.py
+++ b/libAsm4.py
@@ -161,6 +161,40 @@ def getLinkAndDatum():
     return retval
 
 
+# get from the selected datum the corresponding link
+def getLinkAndDatum():
+    retval = (None,None)
+    # only for Asm4 
+    if checkModel() and len(Gui.Selection.getSelection())==1:
+        parentAssembly = App.ActiveDocument.Model
+        # find all the links to Part or Body objects
+        childrenTable = []
+        for objStr in parentAssembly.getSubObjects():
+            # the string ends with a . that must be removed
+            obj = App.ActiveDocument.getObject( objStr[0:-1] )
+            if isLinkToPart(obj):
+                # add it to our tree table if it's a link to an App::Part ...
+                childrenTable.append( obj )
+
+        selObj = Gui.Selection.getSelection()[0]
+        # a datum is selected
+        if selObj.TypeId in datumTypes:
+            # this returns the selection hierarchy in the form 'linkName.datumName.'
+            selTree = Gui.Selection.getSelectionEx("", 0)[0].SubElementNames[0]
+            (parents, toto, dot) = selTree.partition('.'+selObj.Name)
+            link = App.ActiveDocument.getObject( parents )
+            if dot =='.' and link in childrenTable:
+                retval = (link,selObj)
+            else:
+                # see whether the datum is in a group, some people like to do that
+                (parents2, dot, groupName) = parents.partition('.')
+                link2 = App.ActiveDocument.getObject( parents2 )
+                group = App.ActiveDocument.getObject( groupName )
+                if link2 in childrenTable and group.TypeId=='App::DocumentObjectGroup':
+                    retval = (link2,selObj)
+    return retval
+
+
 # get all datums in a part
 def getPartLCS( part ):
     partLCS = [ ]


### PR DESCRIPTION
This is targeted at the development branch. If you prefer a pull request targeted at the master branch, you can merge https://github.com/Zolko-123/FreeCAD_Assembly4/pull/137 instead.

This adds SpinBoxes for specifying absolute AttachmentOffset values (translation and rotation) in the "Place Linked Part" dialog.
When opening the dialog, the default values of these SpinBoxes correspond to the original AttachmentOffset of the linked part.

![Picture2](https://user-images.githubusercontent.com/26200979/98461743-0ca40000-21af-11eb-879c-ecbdaf47276b.png)

Also, if two LCS were selected in the tree view, those LCS are  now pre-selected as attachment-points in the "Place linked Part" dialog.

Usage:

To Move/attach a linked part in an Assembly4 assembly, you now have two options:

workflow a):

1. Select the App::Link for the linked part
2. Clicking the button "Edit Placement of Part" (Tooltip: "Move/Attach a part in the assembly")
3. Optionally, change the values of the SpinBoxes to specify translation and rotation (angle range: -360.00 to 360.00, default: taken from the original AttachmentOffset of the linked part)
4. Optionally, left-click on the button "Rot X + 90°", "Rot Y + 90°" to rotate the AttachmentOffset of the linked part in 90°-steps. The values are taken from the SpinBoxes (see step 3).

workflow b):

1. In the model tree, first select an LCS of the linked part
2. Ctrl + left-click to add to the selection another LCS (in the parent_part) that you want to use as the attachment point
3. Left-click button "Edit Placement of Part" (Tooltip: "Move/Attach a part in the assembly") to open the dialog "Place Linked Part"
4. Observe that the two LCS that were selected in step 1-2 are also preselected in the dialog
5. Optionally, change the value of the SpinBoxes to specify translation and rotation (angle range: -360.00 to 360.00, default: taken from the original AttachmentOffset of the linked part)
6. Optionally, left-click on the button "Rot X + 90°", "Rot Y + 90°" to rotate the AttachmentOffset of the linked part in 90°-steps. The values are taken from the SpinBoxes (see step 5).

**Related feature requests:**

- https://github.com/Zolko-123/FreeCAD_Assembly4/issues/64
- https://github.com/Zolko-123/FreeCAD_Assembly4/issues/85
- https://github.com/Zolko-123/FreeCAD_Assembly4/issues/78
