### PR TITLE
Changes in the behavior of the object and fastener placement commands.

### DIFF
--- a/FastenersLib.py
+++ b/FastenersLib.py
@@ -47,6 +47,7 @@ def isFastener(obj):
         return True
     return False
 
+
 # icon to show in the Menu, toolbar and widget window
 iconFile = os.path.join( Asm4.iconPath , 'Asm4_mvFastener.svg')
 
@@ -252,10 +253,14 @@ class placeFastenerUI():
             if lcs_found:
                 self.attLCSlist.setCurrentItem( lcs_found[0] )
 
+        Gui.Selection.addObserver(self, 0)
 
 
     # this is the end ...
     def finish(self):
+        # remove the  observer
+        Gui.Selection.removeObserver(self)
+        
         Gui.Control.closeDialog()
 
 
@@ -609,6 +614,22 @@ class placeFastenerUI():
         self.ZtranslSpinBox.valueChanged.connect(self.movePart)
 
 
+    def addSelection(self, doc, obj, sub, pnt):
+        selPath = Asm4.getSelectionPath(doc, obj, sub)
+        if len(selPath) > 2:
+            selLinkName = selPath[2]
+            idx = self.parentList.findText(selLinkName)
+            if idx >= 0:
+                self.parentList.setCurrentIndex(idx)
+                selObj = Gui.Selection.getSelection()[0]
+                if selObj:
+                    found = self.attLCSlist.findItems(Asm4.nameLabel(selObj), QtCore.Qt.MatchExactly)
+                    if len(found) > 0:
+                        self.attLCSlist.clearSelection()
+                        found[0].setSelected(True)
+                        self.attLCSlist.scrollToItem(found[0])
+                        self.attLCSlist.setCurrentRow(self.attLCSlist.row(found[0]))
+                        self.onApply()
 
 """
     +-----------------------------------------------+


### PR DESCRIPTION
To the task dialogs 'FastenersLibs.placeFastenerUI' and 'placeLinkCmd.placeLinkUI'
the ability to select HoleAxes in 3D View has been added.

Steps for Part:
1. choose a part;
2. invoke the operation 'Move / Attach a Part in the assembly';
3. in 3D Viwer, select HoleAxes in the part to be attached,
        and in the part to which you want to attach;
        the order of selection is not important.

Steps for Fastener:
1. choose a fastener;
2. invoke the 'Edit Placement of a Fastener' operation;
3. in 3D Viwer, select the HoleAxis in the part to attach to.

PS: When invoking an operation in 3D Viwer, the entire assembly is selected,
    wait for the selection was canceled and then perform the selection of HoleAxes.

PPS: When clicking on an axis, a part or other element in 3D View can be selected,
     it is necessary to select the axis (it may take several clicks).
     The selected axis should be highlighted in corresponding list in the task dialog.

PPPS: When selection is performed there is less problems if the display mode of objects is 'Wireframe'.