### PR TITLE
fixed not found parent item is parent was rename

### DIFF
--- a/placeLinkCmd.py
+++ b/placeLinkCmd.py
@@ -449,7 +449,7 @@ class placeLinkUI():
                     self.Apply()
             # is the selected datum belongs to another part
             else:
-                idx = self.parentList.findText(selLinkName)
+                idx = self.parentList.findText(selLinkName, QtCore.Qt.MatchContains)
                 # the selected LCS is in a child part
                 if idx >= 0:
                     self.parentList.setCurrentIndex(idx)


### PR DESCRIPTION
Hello, I found the problem. When i rename parts then broken dialogue "place linked Part". It doesn't allow  to select a parent.
Maybe FreeCAD is wrong rename not completly? 
I created fix so that can work.
![Screenshot from 2020-12-15 02-03-39](https://user-images.githubusercontent.com/675860/102148997-931ec200-3e7e-11eb-8197-be7891846727.png)
![Screenshot from 2020-12-15 02-04-21](https://user-images.githubusercontent.com/675860/102149011-9914a300-3e7e-11eb-89a8-741abf0a7cb6.png)



Assembly 4 workbench
Current version 0.9.13, 2020-12-01




OS: Debian GNU/Linux 10 (buster) (GNOME/gnome)
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.19.23323 (Git) AppImage
Build type: Release
Branch: master
Hash: 512d5c6141aec52b6eecc67370336a28fde862a6
Python version: 3.8.6
Qt version: 5.12.5
Coin version: 4.0.0
OCC version: 7.4.0
Locale: English/United States (en_US)

