### PR TITLE
Change animation-step-logic to QtTimer-based actions, rather than handling all calculations in loops.

### DIFF
--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -79,6 +79,7 @@ class animateVariable():
         # Initialize States and timing logic.
         self.RunState = self.AnimationState.STOPPED
         self.reverseAnimation = False  # True flags when the animation is "in reverse" for the pendulum mode.
+        self.ForceGUIUpdate = False # True Forces GUI to update on every step of the animation.
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self.onTimerTick)
 
@@ -193,7 +194,8 @@ class animateVariable():
     def setVarValue(self,name,value):
         setattr( self.Variables, name, value )
         App.ActiveDocument.Model.recompute('True')
-        Gui.updateGui()
+        if self.ForceGUIUpdate:
+            Gui.updateGui()
 
     """
     +-----------------------------------------------+
@@ -210,6 +212,9 @@ class animateVariable():
         if self.Loop.isChecked() and self.Pendulum.isChecked():
             self.Loop.setChecked(False)
         return
+
+    def onForceRender(self):
+        self.ForceGUIUpdate = self.ForceRender.isChecked()
 
 
     """
@@ -312,19 +317,30 @@ class animateVariable():
         self.sliderLayout.addWidget(self.sliderMaxValue)
         self.mainLayout.addLayout(self.sliderLayout)
 
-        # loop and pendumlum tick-boxes
+
+        # ForceUpdate, loop and pendulum tick-boxes
+        self.ForceRender = QtGui.QCheckBox()
+        self.ForceRender.setLayoutDirection(QtCore.Qt.LeftToRight)
+        self.ForceRender.setToolTip("Force GUI to update on every step.")
+        self.ForceRender.setText("Force-render every step")
+        self.ForceRender.setChecked(False)
+
         self.Loop = QtGui.QCheckBox()
         self.Loop.setLayoutDirection(QtCore.Qt.RightToLeft)
         self.Loop.setToolTip("Infinite Loop")
         self.Loop.setText("Loop")
         self.Loop.setChecked(False)
-        self.mainLayout.addWidget(self.Loop)
+
         self.Pendulum = QtGui.QCheckBox()
         self.Pendulum.setLayoutDirection(QtCore.Qt.RightToLeft)
         self.Pendulum.setToolTip("Back-and-forth pendulum")
         self.Pendulum.setText("Pendulum")
         self.Pendulum.setChecked(False)
-        self.mainLayout.addWidget(self.Pendulum)
+
+        self.mainLayout.addWidget(self.Loop)
+        self.cbLayout = QtGui.QFormLayout()
+        self.cbLayout.addRow(self.ForceRender, self.Pendulum)
+        self.mainLayout.addLayout(self.cbLayout)
 
         self.mainLayout.addWidget(QtGui.QLabel())
         self.mainLayout.addStretch()
@@ -357,6 +373,7 @@ class animateVariable():
         self.stepValue.valueChanged.connect(      self.onValuesChanged )
         self.Loop.toggled.connect(                self.onLoop )
         self.Pendulum.toggled.connect(            self.onPendulum )
+        self.ForceRender.toggled.connect(self.onForceRender)
         self.CloseButton.clicked.connect(         self.onClose )
         self.StopButton.clicked.connect(self.onStop)
         self.RunButton.clicked.connect(           self.onRun )

--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -57,7 +57,7 @@ class animateVariable():
         # grab the Variables container
         self.Variables = App.ActiveDocument.getObject('Variables')
         self.Model = App.ActiveDocument.getObject('Model')
-        self.Run = True
+        self.setRunning(False)
 
         # Now we can draw the UI
         self.UI.show()
@@ -96,7 +96,7 @@ class animateVariable():
     +-----------------------------------------------+
     """
     def onRun(self):
-        self.Run = True
+        self.setRunning(True)
         # the selected variable
         varName = self.varList.currentText()
         begin   = self.minValue.value()
@@ -116,6 +116,7 @@ class animateVariable():
                     self.runBwd(varName)
             else:
                 self.runFwd(varName)
+        self.setRunning(False)
         return
 
 
@@ -164,14 +165,14 @@ class animateVariable():
 
 
     def onLoop(self):
-        self.Run = False
+        self.setRunning(False)
         if self.Pendulum.isChecked() and self.Loop.isChecked():
             self.Pendulum.setChecked(False)
         return
 
 
     def onPendulum(self):
-        self.Run = False
+        self.setRunning(False)
         if self.Loop.isChecked() and self.Pendulum.isChecked():
             self.Loop.setChecked(False)
         return
@@ -189,7 +190,7 @@ class animateVariable():
     +-----------------------------------------------+
     """
     def sliderMoved(self):
-        self.Run = False
+        self.setRunning(False)
         varName = self.varList.currentText()
         varValue = self.slider.value()
         self.setVarValue(varName,varValue)
@@ -200,7 +201,7 @@ class animateVariable():
 
 
     def onValuesChanged(self):
-        self.Run = False
+        self.setRunning(False)
         self.sliderMinValue.setText( str(self.minValue.value()) )
         self.sliderMaxValue.setText( str(self.maxValue.value()) )
         self.slider.setRange( self.minValue.value(), self.maxValue.value() )
@@ -215,7 +216,7 @@ class animateVariable():
     +-----------------------------------------------+
     """
     def onStop(self):
-        self.Run = False
+        self.setRunning(False)
         return
 
 
@@ -225,7 +226,7 @@ class animateVariable():
     +-----------------------------------------------+
     """
     def onClose(self):
-        self.Run = False
+        self.setRunning(False)
         self.UI.close()
 
 
@@ -330,10 +331,20 @@ class animateVariable():
         self.Loop.toggled.connect(                self.onLoop )
         self.Pendulum.toggled.connect(            self.onPendulum )
         self.CloseButton.clicked.connect(         self.onClose )
-        self.StopButton.clicked.connect(          self.onStop )
+        self.StopButton.clicked.connect(self.onStop)
         self.RunButton.clicked.connect(           self.onRun )
 
 
+
+    """
+        +-----------------------------------------------+
+        |       Helper to toggle Run State              |
+        +-----------------------------------------------+
+    """
+    def setRunning(self, state):
+        self.Run = state
+        self.RunButton.setEnabled(not state)
+        self.StopButton.setEnabled(state)
 
 """
     +-----------------------------------------------+

--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -227,10 +227,12 @@ class animateVariable():
 
 
     def onValuesChanged(self):
-        self.sliderMinValue.setText(str(self.beginValue.value()))
-        self.sliderMaxValue.setText(str(self.endValue.value()))
-        self.slider.setRange(self.beginValue.value(), self.endValue.value())
-        self.slider.setSingleStep( self.stepValue.value() )
+        minVal = min(self.beginValue.value(), self.endValue.value())
+        maxVal = max(self.beginValue.value(), self.endValue.value())
+        self.sliderMinValue.setText(str(minVal))
+        self.sliderMaxValue.setText(str(maxVal))
+        self.slider.setRange(minVal, maxVal)
+        self.slider.setSingleStep(self.stepValue.value())
         return
 
     """


### PR DESCRIPTION
This PR contains some improvements to animateVariable/the Animation Dialog.

Initially, the goal was to just fix a "freeze-crash" when accidentally trying to start an animation with unsuitable user defined values (e.g. RangeBegin<RangeEnd and Step<0).
Eventually however, the run*-functions were ported from explicit loops (in reaction to button presses) to a QtTimer-based approach in order to prevent possible delays (and sleep-calls) inside the GUI-loop.

Also, values should now be updatable while the animation is running.

Please note that I based this on "development" and did not squash in order to make it easier to follow the changes.
Just let me know in case you'd prefer otherwise.
Thanks! :-)


