### PR TITLE
Overhaul of Animation Dialog, make animation related configuration-values persistent

### DIFF
--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -194,6 +194,7 @@ class animateVariable():
     def setVarValue(self,name,value):
         setattr( self.Variables, name, value )
         App.ActiveDocument.Model.recompute('True')
+        self.variableValue.setText('{:.2f}'.format(value))
         if self.ForceGUIUpdate:
             Gui.updateGui()
 
@@ -234,8 +235,8 @@ class animateVariable():
     def onValuesChanged(self):
         minVal = min(self.beginValue.value(), self.endValue.value())
         maxVal = max(self.beginValue.value(), self.endValue.value())
-        self.sliderMinValue.setText(str(minVal))
-        self.sliderMaxValue.setText(str(maxVal))
+        self.sliderLeftValue.setText(str(minVal))
+        self.sliderRightValue.setText(str(maxVal))
         self.slider.setRange(minVal, maxVal)
         self.slider.setSingleStep(self.stepValue.value())
         return
@@ -304,17 +305,27 @@ class animateVariable():
         self.mainLayout.addLayout(self.formLayout)
         self.mainLayout.addWidget(QtGui.QLabel())
 
+        # Current Variable Value
+        self.curVarLayout = QtGui.QHBoxLayout()
+        self.variableValue = QtGui.QLabel('Variable')
+        self.curVarLayout.addWidget(QtGui.QLabel('Current Value:'))
+        self.curVarLayout.addStretch()
+        self.curVarLayout.addWidget(self.variableValue)
+
+        self.mainLayout.addLayout(self.curVarLayout)
+
         # slider
         self.sliderLayout = QtGui.QHBoxLayout()
         self.slider = QtGui.QSlider()
         self.slider.setOrientation(QtCore.Qt.Orientation.Horizontal)
         self.slider.setRange(0, 10)
         self.slider.setTickInterval(0)
-        self.sliderMinValue = QtGui.QLabel('Min')
-        self.sliderMaxValue = QtGui.QLabel('Max')
-        self.sliderLayout.addWidget(self.sliderMinValue)
+        self.sliderLeftValue = QtGui.QLabel('Begin')
+        self.sliderRightValue = QtGui.QLabel('End')
+        self.sliderLayout.addWidget(self.sliderLeftValue)
         self.sliderLayout.addWidget(self.slider)
-        self.sliderLayout.addWidget(self.sliderMaxValue)
+        self.sliderLayout.addWidget(self.sliderRightValue)
+
         self.mainLayout.addLayout(self.sliderLayout)
 
 

--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -285,21 +285,26 @@ class animateVariable():
         # Range Minimum
         self.beginValue = QtGui.QDoubleSpinBox()
         self.beginValue.setRange(-1000000.0, 1000000.0)
+        self.beginValue.setKeyboardTracking(False)
         self.formLayout.addRow(QtGui.QLabel('Range Begin'), self.beginValue)
         # Maximum
         self.endValue = QtGui.QDoubleSpinBox()
         self.endValue.setRange(-1000000.0, 1000000.0)
+        self.endValue.setKeyboardTracking(False)
         self.formLayout.addRow(QtGui.QLabel('Range End'), self.endValue)
         # Step
         self.stepValue = QtGui.QDoubleSpinBox()
         self.stepValue.setRange( -10000.0, 10000.0 )
         self.stepValue.setValue( 1.0 )
-        self.formLayout.addRow(QtGui.QLabel('Step Size'),self.stepValue)
+        self.stepValue.setKeyboardTracking(False)
+        self.formLayout.addRow(QtGui.QLabel('Step Size'), self.stepValue)
+        
         # Sleep
         self.sleepValue = QtGui.QDoubleSpinBox()
         self.sleepValue.setRange( 0.0, 10.0 )
         self.sleepValue.setValue( 0.0 )
         self.sleepValue.setSingleStep(0.01)
+        self.sleepValue.setKeyboardTracking(False)
         self.formLayout.addRow(QtGui.QLabel('Sleep (s)'),self.sleepValue)
         # apply the layout
         self.mainLayout.addLayout(self.formLayout)
@@ -368,8 +373,15 @@ class animateVariable():
         self.StopButton.setEnabled(False)
         # Run button
         self.RunButton = QtGui.QPushButton('Run')
-        self.RunButton.setDefault(True)
         self.buttonLayout.addWidget(self.RunButton)
+
+        # Add an invisibly dummy button to circumvent QDialogs default-button behavior.
+        # We need the enter key to trigger spinbox-commits only, without also triggering button actions.
+        self.DummyButton = QtGui.QPushButton('Dummy')
+        self.DummyButton.setDefault(True)
+        self.DummyButton.setVisible(False)
+        self.buttonLayout.addWidget(self.DummyButton)
+
         # add buttons to layout
         self.mainLayout.addLayout(self.buttonLayout)
 
@@ -379,6 +391,7 @@ class animateVariable():
         # Actions
         self.varList.currentIndexChanged.connect( self.onSelectVar )
         self.slider.sliderMoved.connect(          self.sliderMoved)
+        self.slider.valueChanged.connect(self.sliderMoved)
         self.beginValue.valueChanged.connect(self.onValuesChanged)
         self.endValue.valueChanged.connect(self.onValuesChanged)
         self.stepValue.valueChanged.connect(      self.onValuesChanged )

--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -49,6 +49,13 @@ class animateVariable():
         self.UI = QtGui.QDialog()
         self.drawUI()
 
+        # Initialize States and timing logic.
+        self.RunState = self.AnimationState.STOPPED
+        self.reverseAnimation = False  # True flags when the animation is "in reverse" for the pendulum mode.
+        self.ForceGUIUpdate = False  # True Forces GUI to update on every step of the animation.
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.onTimerTick)
+
 
     def GetResources(self):
         return {"MenuText": "Animate Assembly",
@@ -71,21 +78,22 @@ class animateVariable():
     +-----------------------------------------------+
     """
     def Activated(self):
-
         # grab the Variables container
         self.Variables = App.ActiveDocument.getObject('Variables')
         self.Model = App.ActiveDocument.getObject('Model')
 
-        # Initialize States and timing logic.
-        self.RunState = self.AnimationState.STOPPED
-        self.reverseAnimation = False  # True flags when the animation is "in reverse" for the pendulum mode.
-        self.ForceGUIUpdate = False # True Forces GUI to update on every step of the animation.
-        self.timer = QtCore.QTimer()
-        self.timer.timeout.connect(self.onTimerTick)
-
+        self.updateVarList()
+        
         # Now we can draw the UI
         self.UI.show()
 
+
+    """
+    +------------------------------------------------+
+    |  fill default values when selecting a variable |
+    +------------------------------------------------+
+    """
+    def updateVarList(self):
         # select the Float variables that are in the "Variables" group
         self.varList.clear()
         for prop in self.Variables.PropertiesList:
@@ -94,12 +102,8 @@ class animateVariable():
                     self.varList.addItem(prop)
 
 
-    """
-    +------------------------------------------------+
-    |  fill default values when selecting a variable |
-    +------------------------------------------------+
-    """
     def onSelectVar(self):
+        self.update(self.AnimationRequest.STOP)
         # the currently selected variable
         selectedVar = self.varList.currentText()
         # if it's indeed a property in the Variables object (one never knows)

--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -250,6 +250,14 @@ class animateVariable():
         if curVal != sliderVal:
             self.setVarValue(varName, sliderVal)
 
+        # Check whether the end of the range can actually be reached with the current stepping.
+        # Flag label if needed.
+        rangeShort = (self.slider.rightValue() < endVal) if (beginVal < endVal) else (self.slider.rightValue() > endVal)
+        if rangeShort:
+            self.sliderRightValue.setStyleSheet("background-color: tomato")
+        else:
+            self.sliderRightValue.setStyleSheet("background-color: none")
+
 
     """
     +-----------------------------------------------+
@@ -336,6 +344,10 @@ class animateVariable():
         self.slider.setTickInterval(0)
         self.sliderLeftValue = QtGui.QLabel('Begin')
         self.sliderRightValue = QtGui.QLabel('End')
+        tt = "The last reachable variable value with the given stepping. "
+        tt += "Flagged red in case this is not equal to the intended value. "
+        tt += "The last step of the animation will be reduced to stay inside the configured limits."
+        self.sliderRightValue.setToolTip(tt)
         self.sliderLayout.addWidget(self.sliderLeftValue)
         self.sliderLayout.addWidget(self.slider)
         self.sliderLayout.addWidget(self.sliderRightValue)

--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -8,7 +8,7 @@
 
 
 
-import os, time
+import os, numpy
 
 from PySide import QtGui, QtCore
 from enum import Enum
@@ -301,17 +301,17 @@ class animateVariable():
         self.formLayout.addRow(QtGui.QLabel('Select Variable'),self.varList)
         # Range Minimum
         self.beginValue = QtGui.QDoubleSpinBox()
-        self.beginValue.setRange(-1000000.0, 1000000.0)
+        self.beginValue.setRange(numpy.finfo(float).min, numpy.finfo(float).max)
         self.beginValue.setKeyboardTracking(False)
         self.formLayout.addRow(QtGui.QLabel('Range Begin'), self.beginValue)
         # Maximum
         self.endValue = QtGui.QDoubleSpinBox()
-        self.endValue.setRange(-1000000.0, 1000000.0)
+        self.endValue.setRange(numpy.finfo(float).min, numpy.finfo(float).max)
         self.endValue.setKeyboardTracking(False)
         self.formLayout.addRow(QtGui.QLabel('Range End'), self.endValue)
         # Step
         self.stepValue = QtGui.QDoubleSpinBox()
-        self.stepValue.setRange( 0.01, 10000.0 )
+        self.stepValue.setRange( 0.01, numpy.finfo(float).max )
         self.stepValue.setValue( 1.0 )
         self.stepValue.setKeyboardTracking(False)
         self.formLayout.addRow(QtGui.QLabel('Step Size'), self.stepValue)


### PR DESCRIPTION
Hi Zolko,

here are the first two changes requested after my last PR (#175).
Actually having the variable displayed above the slider made some shortcomings with slider handling more obvious.
I hence decided to give the dialog a small handling-overhaul.
Furthermore, all Variables will now have their associated configuration stored directly in the doc-file (using an additional property; basically as suggested in #161, which should be fixed with this PR.)

Just let me know if you have comments and whatever else might be needed to get this merged. :-)

I'll move ahead with animation-recording as suggested in your last post here:
https://github.com/Zolko-123/FreeCAD_Assembly4/pull/175#issuecomment-792345200=

Cheers!

PS: Again, PR based on development, non-squashed for details.