### PR TITLE
Allow animating variables from different documents

### DIFF
--- a/AnimationLib.py
+++ b/AnimationLib.py
@@ -465,6 +465,9 @@ class animateVariable(animationProvider):
 
     def onDocChanged(self):
         if App.ActiveDocument != self.ActiveDocument:
+            # Check if AnimatedDocument still exists
+            if not self.AnimatedDocument in App.listDocuments().values():
+                self.AnimatedDocument = None
             self.onStop()
             self.Activated()
 


### PR DESCRIPTION
This is a short patch for animating variables of any document, instead of only `App.ActiveDocument`. This is useful for synchronizing values among multiple `Model`s. Seems to work well so far.