### PR TITLE
Select the first LCS if there is one

### DIFF
--- a/placeLinkUI.py
+++ b/placeLinkUI.py
@@ -165,6 +165,11 @@ class placeLinkUI():
         if lcs_found:
             # ... and select it
             self.partLCSlist.setCurrentItem( lcs_found[0] )
+        else:
+            # If no LCS is selected, select the first LCS if there is one
+            firstLCSItem = self.partLCSlist.item(0)
+            if firstLCSItem is not None:
+                self.partLCSlist.setCurrentItem(firstLCSItem)
 
         # find the oldPart in the part list...
         if old_Parent == 'Parent Assembly':


### PR DESCRIPTION
Hi @Zolko-123,

If I place a part/link, pick a LCS from the **Parent Part** and forgot to pick a LCS from the **Linked Part**,
I will get the warning: **Problem in Selection**
<img width="200" alt="Problem in Selection" src="https://user-images.githubusercontent.com/94402613/154842535-53946bdb-78ab-4908-b613-fd6c65d76fb4.png">

So I figured It could make sense, to have the first LCS already selected, if there is one.
<img width="200" alt="No Problem in Selection" src="https://user-images.githubusercontent.com/94402613/154842594-bb8ac9c9-c1ca-46cc-9471-44ab4db762df.png">

Especially If I have to insert quite a lot of parts and they usually have only one LCS anyway.
It saved me quite some time, not to click all the time the first and only LCS and close the warning window.

This change does not effect the Move/Attach Function.

Cheers
Semi

