### PR TITLE
Set width of ObjectName column in new configuration spreadsheets

### DIFF
--- a/configurationEngine.py
+++ b/configurationEngine.py
@@ -28,6 +28,7 @@ OFFSET_POS_Z_COL        = 'F'
 OFFSET_ROT_YAW_COL      = 'G'
 OFFSET_ROT_PITCH_COL    = 'H'
 OFFSET_ROT_ROLL_COL     = 'I'
+NAME_COL_WIDTH          = 250
 
 
 
@@ -61,6 +62,8 @@ def createConfig(name, description):
     conf.set(OFFSET_ROT_YAW_COL   + headerRow, 'Rot. Yaw')
     conf.set(OFFSET_ROT_PITCH_COL + headerRow, 'Rot. Pitch')
     conf.set(OFFSET_ROT_ROLL_COL  + headerRow, 'Rot. Roll')
+    # Set name column width to default value
+    conf.setColumnWidth(OBJECT_NAME_COL, NAME_COL_WIDTH)
     return conf
 
 


### PR DESCRIPTION
Since ObjectName in most cases is wider than the default column width, you have to stretch the column width manually to see the full object name. When switching through multiple configurations this is slightly annoying. This PR sets the default "Column A" width to 250, so most names will be visible in full.

Before:
![Before](https://user-images.githubusercontent.com/82042580/163713869-0ba9757a-1e36-4cbc-bd97-6f08899cc094.png)

After:
![ObjectName width](https://user-images.githubusercontent.com/82042580/163713871-f8172a8c-4a56-4c90-aec0-356c95166cb0.png)

