### PR TITLE
Save configuration properties from items in groups

### DIFF
--- a/configurationEngine.py
+++ b/configurationEngine.py
@@ -424,7 +424,7 @@ def SaveSubObjects(conf, container):
         if obj.isDerivedFrom('Part::Feature') or obj.isDerivedFrom('App::Link') or obj.isDerivedFrom('App::Part'):
             SaveObject(conf, obj)
         # save subobjects in groups, but not the groups themselves. Skip default Asm4 groups
-        elif obj.TypeId == 'App::DocumentObjectGroup' and obj.Name != 'Configurations' and  obj.Name != 'Constraints':
+        elif obj.TypeId == 'App::DocumentObjectGroup' and obj.Name != 'Configurations' and  obj.Name != 'Constraints' and  obj.Name != 'Measures':
             SaveSubObjects(conf, obj)
 
 

--- a/configurationEngine.py
+++ b/configurationEngine.py
@@ -423,6 +423,9 @@ def SaveSubObjects(conf, container):
         # only save properties of certain objects
         if obj.isDerivedFrom('Part::Feature') or obj.isDerivedFrom('App::Link') or obj.isDerivedFrom('App::Part'):
             SaveObject(conf, obj)
+        # save subobjects in groups, but not the groups themselves. Skip default Asm4 groups
+        elif obj.TypeId == 'App::DocumentObjectGroup' and obj.Name != 'Configurations' and  obj.Name != 'Constraints':
+            SaveSubObjects(conf, obj)
 
 
 def SaveObject(conf, obj):
@@ -506,8 +509,8 @@ def restoreSubObjects(conf, container):
 
 
 def restoreObject(conf, obj):
-    # parse App::Part containers, and only those
-    if obj.TypeId == 'App::Part':
+    # parse App::Part containers and group subobjects
+    if obj.TypeId == 'App::Part' or obj.TypeId == 'App::DocumentObjectGroup':
         restoreSubObjects(conf, obj)
 
     parentObj, objFullName = obj.Parents[0]


### PR DESCRIPTION
When saving a configuration, only items either directly under the Assembly container, or items in an App::Part container is saved.
This makes configuration useless if you want to organize your assembly in groups (folders) and subgroups.

This PR aims to add support for groups in Asm4 configuration, so that e.g. all fasteners or all LCSs in an assembly can be organized in groups, and the properties of the items in the group are stored in configurations, but not the groups themselves (I don't know if they should.. perhaps?)