### PR TITLE
Fix 'Hide/Show LCS buttons does not work for items in groups' issue

### DIFF
--- a/Asm4_libs.py
+++ b/Asm4_libs.py
@@ -39,7 +39,7 @@ partInfo =[     'PartID',                       \
                 'PartDescription',              \
                 'PartSupplier']
 
-containerTypes = [  'App::Part', 'PartDesign::Body' ]
+containerTypes = [  'App::Part', 'App::DocumentObjectGroup', 'PartDesign::Body' ]
 
 
 

--- a/showHideLcsCmd.py
+++ b/showHideLcsCmd.py
@@ -103,19 +103,11 @@ def showChildLCSs(obj, show, processedLinks):
             linkedObj = obj.LinkedObject.Document.getObject(objName[0:-1])
             showChildLCSs(linkedObj, show, processedLinks)
     # if it's a container
-    else:
-        if obj.TypeId in Asm4.containerTypes:
-            for subObjName in obj.getSubObjects(1):
-                subObj = obj.getSubObject(subObjName, 1)    # 1 for returning the real object
-                if subObj != None:
-                    if subObj.TypeId in Asm4.datumTypes:
-                        #subObj.Visibility = show
-                        # Apparently obj.Visibility API is very slow
-                        # Using the ViewObject.show() and ViewObject.hide() API runs at least twice faster
-                        if show:
-                            subObj.ViewObject.show()
-                        else:
-                            subObj.ViewObject.hide()
+    elif obj.TypeId in Asm4.containerTypes:
+        for subObjName in obj.getSubObjects(1):
+            subObj = obj.getSubObject(subObjName, 1)    # 1 for returning the real object
+            if subObj != None:
+                showChildLCSs(subObj, show, processedLinks)
 
 
 


### PR DESCRIPTION
Fixes issue #307. Seems to work with groups, parts, bodies and links.