### PR TITLE
Wschildbach fix insert link temporary doc

### DIFF
--- a/insertLinkCmd.py
+++ b/insertLinkCmd.py
@@ -178,7 +178,7 @@ class insertLink():
             # which don't have the Temporary attribute
             try:
                 docTemporary = doc.Temporary 
-            except:
+            except AttributeError:
                 docTemporary = False
                 
             if not docTemporary:

--- a/insertLinkCmd.py
+++ b/insertLinkCmd.py
@@ -174,8 +174,14 @@ class insertLink():
         else:
             docList = [doc]
         for doc in docList:
-            # don't consider temporary documents
-            if not doc.Temporary:
+            # don't consider temporary documents. Guard against older versions of FreeCad
+            # which don't have the Temporary attribute
+            try:
+                docTemporary = doc.Temporary 
+            except:
+                docTemporary = False
+                
+            if not docTemporary:
                 for obj in doc.findObjects("App::Part"):
                     # we don't want to link to itself to the 'Model' object
                     # other App::Part in the same document are OK 


### PR DESCRIPTION
When assembly4 is used with the 0.19 build 19694 version of FreeCad a part is inserted into a model, one gets an error message.

```
Running the Python command 'Asm4_insertLink' failed:
Traceback (most recent call last):
  File "C:\Users\wschi\AppData\Roaming\FreeCAD\Mod\Assembly4\insertLinkCmd.py", line 110, in Activated
    self.lookForParts()
  File "C:\Users\wschi\AppData\Roaming\FreeCAD\Mod\Assembly4\insertLinkCmd.py", line 179, in lookForParts
    docTemporary = doc.Temporary 

'App.Document' object has no attribute 'Temporary'
```
It appears that some versions of FreeCad don't have the doc.Temporary attribute. This pull request guards against this situation.