### PR TITLE
Fix X and Z rotation swap issue

### DIFF
--- a/placeLinkUI.py
+++ b/placeLinkUI.py
@@ -497,9 +497,9 @@ class placeLinkUI():
     def reorientLink( self ):
         moveXYZ = App.Placement( App.Vector(self.Xtranslation,self.Ytranslation,self.Ztranslation), self.old_LinkRotation )
         # New AttachmentOffset rotation of the link is difference between set rotation angles and original AttachmentOffset rotation of the link
-        rotationX = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(1,0,0), self.XrotationAngle - self.old_LinkRotation.toEuler()[0] ))
+        rotationX = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(1,0,0), self.XrotationAngle - self.old_LinkRotation.toEuler()[2] ))
         rotationY = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(0,1,0), self.YrotationAngle - self.old_LinkRotation.toEuler()[1] ))
-        rotationZ = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(0,0,1), self.ZrotationAngle - self.old_LinkRotation.toEuler()[2] ))
+        rotationZ = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(0,0,1), self.ZrotationAngle - self.old_LinkRotation.toEuler()[0] ))
         self.selectedObj.AttachmentOffset = moveXYZ * rotationX * rotationY * rotationZ
         self.selectedObj.recompute()
 

--- a/placeLinkUI.py
+++ b/placeLinkUI.py
@@ -87,9 +87,11 @@ class placeLinkUI():
         self.Xtranslation = self.old_LinkPosition[0]
         self.Ytranslation = self.old_LinkPosition[1]
         self.Ztranslation = self.old_LinkPosition[2]
-        self.XrotationAngle = self.old_LinkRotation.toEuler()[0]
-        self.YrotationAngle = self.old_LinkRotation.toEuler()[1]
-        self.ZrotationAngle = self.old_LinkRotation.toEuler()[2]
+
+        # See https://wiki.freecadweb.org/Placement#Position_and_Yaw.2C_Pitch_and_Roll
+        self.XrotationAngle = self.old_LinkRotation.getYawPitchRoll()[2] # Roll is around X
+        self.YrotationAngle = self.old_LinkRotation.getYawPitchRoll()[1] # Pitch is around Y
+        self.ZrotationAngle = self.old_LinkRotation.getYawPitchRoll()[0] # Yaw is around Z
         
         # save previous view properties
         self.old_OverrideMaterial = self.selectedObj.ViewObject.OverrideMaterial

--- a/placeLinkUI.py
+++ b/placeLinkUI.py
@@ -497,9 +497,9 @@ class placeLinkUI():
     def reorientLink( self ):
         moveXYZ = App.Placement( App.Vector(self.Xtranslation,self.Ytranslation,self.Ztranslation), self.old_LinkRotation )
         # New AttachmentOffset rotation of the link is difference between set rotation angles and original AttachmentOffset rotation of the link
-        rotationX = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(1,0,0), self.XrotationAngle - self.old_LinkRotation.toEuler()[2] ))
-        rotationY = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(0,1,0), self.YrotationAngle - self.old_LinkRotation.toEuler()[1] ))
-        rotationZ = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(0,0,1), self.ZrotationAngle - self.old_LinkRotation.toEuler()[0] ))
+        rotationX = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(1,0,0), self.XrotationAngle - self.old_LinkRotation.getYawPitchRoll()[2] ))
+        rotationY = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(0,1,0), self.YrotationAngle - self.old_LinkRotation.getYawPitchRoll()[1] ))
+        rotationZ = App.Placement( App.Vector(0.00, 0.00, 0.00), App.Rotation( App.Vector(0,0,1), self.ZrotationAngle - self.old_LinkRotation.getYawPitchRoll()[0] ))
         self.selectedObj.AttachmentOffset = moveXYZ * rotationX * rotationY * rotationZ
         self.selectedObj.recompute()
 


### PR DESCRIPTION
It appears to me that Z and X rotation values were swapped in `placeLinkUI.py`. Based on the [Yaw-Pitch-Roll documentation](https://wiki.freecadweb.org/Placement#Position_and_Yaw.2C_Pitch_and_Roll) found in the wiki, the mapping is as follows:

* Yaw - Z
* Pitch - Y
* Roll - X

Which means the value returned by `getYawPitchRoll()` is a tuple of degrees for the axis of (Z, Y, X) respectively - not (X,Y,Z).

In addition, the [`toEuler()`](https://github.com/FreeCAD/FreeCAD/blob/68053e4f4d75713887771db948bcd2d854d6f8cb/src/Base/RotationPyImp.cpp#L475) function appears to be an alias to `getYawPitchRoll()` function, so I changed the code to call it directly.

I guess `placePartUI` should be fixed but I don't see the UI button to invoque it.