### PR TITLE
Fix Document Name for Fastners.

### DIFF
--- a/makeBomCmd.py
+++ b/makeBomCmd.py
@@ -377,8 +377,7 @@ class makeBOM:
 
             if level > 0 and level <= max_level:
 
-                doc_name = obj.Document.Name
-
+                doc_name = os.path.splitext(os.path.basename(obj.Document.FileName))[0]
                 obj_label = re.sub(r'[0-9]+$', '', obj.Label)
 
                 if obj_label in self.PartsList:


### PR DESCRIPTION
`obj.Document.Name` does not have a Document Name like the others, it messes up with some characters that are converted to _ and cannot be restored. 

This is an example of what was happening
![image](https://user-images.githubusercontent.com/1277920/194775548-b19b370d-8428-4a01-866c-0500b43607f8.png)
