### PR TITLE
Stabilize auto-numbering behavior

### DIFF
--- a/Asm4_libs.py
+++ b/Asm4_libs.py
@@ -344,20 +344,32 @@ def getDependenciesList( CompleteSelection ):
     |           get the next instance's name        |
     +-----------------------------------------------+
 """
-def nextInstance( name, startAtOne=False ):
-    # if there is no such name, return the original
-    if not App.ActiveDocument.getObject(name) and not startAtOne:
-        return name
-    # there is already one, we increment
-    else:
-        if startAtOne:
-            instanceNum = 1
-        else:
-            instanceNum = 2
-        while App.ActiveDocument.getObject( name+'_'+str(instanceNum) ):
-            instanceNum += 1
-        return name+'_'+str(instanceNum)
+def nextInstance( name ):
+    autoNum = 1
 
+    # Find the auto-numbering if exist
+    name,num = getNameWithoutAutoNumbering(name)
+
+    if num > -1:
+        autoNum = num
+
+    # Finding available proposed name
+    while App.ActiveDocument.getObject(name + '_' + '{:03}'.format(autoNum)):
+            autoNum += 1
+
+    return name + '/' + '{:03}'.format(autoNum)
+
+def getNameWithoutAutoNumbering( name ):
+    num = -1
+
+    pos = name.rfind('/')
+    if pos > -1:
+        num = name[pos+1:]
+        if num.isnumeric():
+            name = name[:pos]
+            num = int(num)
+
+    return name,num
 
 
 """

--- a/insertLinkCmd.py
+++ b/insertLinkCmd.py
@@ -147,20 +147,8 @@ class insertLink():
             partFound = self.partList.findItems( origPartText, QtCore.Qt.MatchExactly )
             if partFound:
                 self.partList.setCurrentItem(partFound[0])
-                # self.onItemClicked(partFound[0])
-                # if the last character is a number, we increment this number
-                origName = self.origLink.Label
-                lastChar = origName[-1]
-                if lastChar.isnumeric():
-                    (rootName,sep,num) = origName.rpartition('_')
-                    if rootName=="":
-                        rootName = origName[:-3]
-                    proposedLinkName = Asm4.nextInstance(rootName,startAtOne=False)
-                # else we take the next instance
-                else:
-                    proposedLinkName = Asm4.nextInstance(origName,startAtOne=False)
-                # set the proposed name in the entry field
-                self.linkNameInput.setText( proposedLinkName )
+                name,num = Asm4.getNameWithoutAutoNumbering(self.origLink.Label)
+                self.linkNameInput.setText(name)
 
         # show the UI
         self.UI.show()
@@ -247,14 +235,15 @@ class insertLink():
     +-----------------------------------------------+
     """
     def onCreateLink(self):
-        # parse the selected items 
+        # parse the selected items
         selectedPart = []
         for selected in self.partList.selectedIndexes():
             # get the selected part
             selectedPart = self.allParts[ selected.row() ]
 
         # get the name of the link (as it should appear in the tree)
-        linkName = self.linkNameInput.text()
+        linkName = Asm4.nextInstance(self.linkNameInput.text())
+
         # repair broken link
         if self.brokenLink and selectedPart:
             self.origLink.LinkedObject = selectedPart
@@ -372,6 +361,9 @@ class insertLink():
         self.mainLayout.addWidget(self.partList)
         self.mainLayout.addWidget(QtGui.QLabel("Name for the link :"))
         self.mainLayout.addWidget(self.linkNameInput)
+        label = QtGui.QLabel('Auto-numbering (/001, /002 etc.) will be added to the end of the name')
+        label.setStyleSheet('font: 10px;')
+        self.mainLayout.addWidget(label)
         self.mainLayout.addWidget(QtGui.QLabel(' '))
         self.buttonsLayout = QtGui.QHBoxLayout()
         self.buttonsLayout.addWidget(self.cancelButton)

--- a/newDatumCmd.py
+++ b/newDatumCmd.py
@@ -107,7 +107,7 @@ class newDatum:
         # check that we have somewhere to put our stuff
         selectedObj = self.checkSelection()
         # default name increments the datum type's end numeral
-        proposedName = Asm4.nextInstance( self.datumName, startAtOne=True )
+        proposedName = Asm4.nextInstance( self.datumName )
 
         # check whether we have selected a container
         if selectedObj.TypeId in self.containers:

--- a/variantLinkCmd.py
+++ b/variantLinkCmd.py
@@ -145,7 +145,7 @@ class makeVariantLink():
                 lastChar = origName[-1]
                 if lastChar.isnumeric():
                     (rootName,sep,num) = origName.rpartition('_')
-                    proposedLinkName = Asm4.nextInstance(rootName,startAtOne=True)
+                    proposedLinkName = Asm4.nextInstance(rootName)
                 # else we take the next instance
                 else:
                     proposedLinkName = Asm4.nextInstance(origName)


### PR DESCRIPTION
More stable solution for the auto-numbering.
Asm4.nextInstance will always add "/001", "/002" and so on to the name.
User can still specify his own numbering in the same concept if needed, but better leave the logic do it's own work automatically.

Previous implementation stripped numbers from the name even when not added anything, which cause a mess for parts names that include "_number" at the end.
Since FreeCAD naming converts many characters that it doesn't like to undescore without any notice, meaning many names might end up into that category, including those that have dashes "-" and other characters as well.