### PR TITLE
Following issue #382

### DIFF
--- a/VariablesLib.py
+++ b/VariablesLib.py
@@ -188,6 +188,7 @@ class addVariable():
         # Variable Value
         self.varValue = QtGui.QDoubleSpinBox()
         self.varValue.setRange( -1000000.0, 1000000.0 )
+        self.varValue.setDecimals( 6 )
         self.formLayout.addRow(QtGui.QLabel('Value'),self.varValue)
         # Documentation
         self.description = QtGui.QTextEdit()


### PR DESCRIPTION
Seems that number of decimals has an effect on the min/max range, tried with 8, I put 6 in the code. Perhaps could be good not to use QDoubleSpinBox but another control, need to dig a bit.