### PR TITLE
Add initial interference checks

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -150,6 +150,8 @@ class Assembly4Workbench(Workbench):
         self.dot()
         import makeBomCmd          # creates the parts list
         self.dot()
+        import checkInterference   # check interferences btween parts inside the Assembly
+        self.dot()
         import exportFiles         # creates a hierarchical tree listing of files in an assembly
         self.dot()
         import HelpCmd             # shows a basic help window
@@ -235,6 +237,8 @@ class Assembly4Workbench(Workbench):
                         "Asm4_makeLocalBOM",
                         "Asm4_makeBOM",
                         "Asm4_listLinkedFiles",
+                        "Asm4_checkInterference",
+                        "Asm4_removeInterference",
                         "Asm4_Measure",
                         'Asm4_showLcs',
                         'Asm4_hideLcs',
@@ -280,6 +284,8 @@ class Assembly4Workbench(Workbench):
                         "Separator",
                         "Asm4_makeBOM",
                         "Asm4_listLinkedFiles",
+                        "Asm4_checkInterference",
+                        "Asm4_removeInterference",
                         "Asm4_Measure",
                         "Asm4_variablesCmd",
                         "Asm4_openConfigurations",

--- a/Resources/icons/Asm4_Interference_Check.svg
+++ b/Resources/icons/Asm4_Interference_Check.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Svg Vector Icons : http://www.onlinewebfonts.com/icon -->
+
+<svg
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 32 32"
+   enable-background="new 0 0 1000 1000"
+   xml:space="preserve"
+   id="svg24"
+   sodipodi:docname="Asm4_Interference_Check.svg"
+   width="32"
+   height="32"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs28" /><sodipodi:namedview
+   id="namedview26"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="10.196272"
+   inkscape:cx="-5.3941283"
+   inkscape:cy="30.746532"
+   inkscape:window-width="1920"
+   inkscape:window-height="1136"
+   inkscape:window-x="0"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g22" />
+<metadata
+   id="metadata2"> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
+<g
+   id="g22"
+   transform="matrix(0.03265282,0,0,0.03265282,-0.32661882,-0.32657326)"
+   style="stroke-width:30.6252"><g
+     id="g1716"
+     transform="matrix(1.0846626,0,0,1.0846942,-21.187767,-43.126685)"
+     style="stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"><circle
+       style="fill:#cccccc;fill-opacity:1;stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       id="path1597"
+       cx="597.13208"
+       cy="612.01807"
+       r="271.60852" /><rect
+       style="fill:#cccccc;fill-opacity:1;stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1463"
+       width="471.50348"
+       height="455.88138"
+       x="92.284813"
+       y="117.82006" /><path
+       id="rect1463-3"
+       style="fill:#ff00ff;fill-opacity:1;stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       d="M 563.78827,342.75613 A 271.60852,271.60852 0 0 0 329.91204,573.70142 h 233.87623 z" /></g></g>
+</svg>

--- a/Resources/icons/Asm4_Interference_Cleanup.svg
+++ b/Resources/icons/Asm4_Interference_Cleanup.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Svg Vector Icons : http://www.onlinewebfonts.com/icon -->
+
+<svg
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 32 32"
+   enable-background="new 0 0 1000 1000"
+   xml:space="preserve"
+   id="svg24"
+   sodipodi:docname="Asm4_Interference_Cleanup.svg"
+   width="32"
+   height="32"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs28" /><sodipodi:namedview
+   id="namedview26"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="10.956657"
+   inkscape:cx="7.6665721"
+   inkscape:cy="16.200197"
+   inkscape:window-width="1920"
+   inkscape:window-height="1136"
+   inkscape:window-x="0"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g22" />
+<metadata
+   id="metadata2"> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
+<g
+   id="g22"
+   transform="matrix(0.03265282,0,0,0.03265282,-0.32661882,-0.32657326)"
+   style="stroke-width:30.6252"><g
+     id="g1716"
+     transform="matrix(1.0846626,0,0,1.0846942,-21.187767,-43.126685)"
+     style="stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"><circle
+       style="fill:#cccccc;fill-opacity:1;stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       id="path1597"
+       cx="597.13208"
+       cy="612.01807"
+       r="271.60852" /><rect
+       style="fill:#cccccc;fill-opacity:1;stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1463"
+       width="471.50348"
+       height="455.88138"
+       x="92.284813"
+       y="117.82006" /><path
+       id="rect1463-3"
+       style="fill:#ff00ff;fill-opacity:1;stroke:#000000;stroke-width:19.7641;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       d="M 563.78827,342.75613 A 271.60852,271.60852 0 0 0 329.91204,573.70142 h 233.87623 z" /></g><path
+     style="fill:none;stroke:#ff0000;stroke-width:91.87567873;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 190.76841,174.13155 867.1073,850.47044"
+     id="path2162" /><path
+     style="fill:none;stroke:#ff0000;stroke-width:91.87567873;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 871.69049,132.34406 115.13895,888.8956"
+     id="path2164" /></g>
+</svg>

--- a/checkInterference.py
+++ b/checkInterference.py
@@ -167,7 +167,7 @@ class checkInterference:
             model = doc.Assembly
             model.Visibility = False
 
-        doc.Parts.Visibility = True
+        doc.Parts.Visibility = False
         for obj in doc.Parts.Group:
             try:
                 obj.Visibility = False
@@ -193,7 +193,7 @@ class checkInterference:
         doc.recompute()
 
         i = 0
-        c = 1
+        c = 0
 
         checked_dict = dict()
 

--- a/checkInterference.py
+++ b/checkInterference.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# coding: utf-8
+#
+# checkInterference.py
+#
+# Check interferences between parts
+
+import os
+import json
+import re
+import random as rnd
+
+from PySide import QtGui, QtCore
+import FreeCADGui as Gui
+import FreeCAD as App
+
+import Asm4_libs as Asm4
+import Part
+
+class checkInterference:
+
+    def __init__(self):
+        super(checkInterference, self).__init__()
+
+    def GetResources(self):
+
+        menutext = "Check Intereferences"
+        tooltip  = "Check interferences among assembled objects (may take time)"
+        iconFile = os.path.join(Asm4.iconPath, 'Asm4_Interference_Check.svg')
+
+        return {
+            "MenuText": menutext,
+            "ToolTip": tooltip,
+            "Pixmap": iconFile
+        }
+
+    def IsActive(self):
+        if Asm4.getAssembly() is None:
+            return False
+        else:
+            return True
+
+    def Activated(self):
+        self.UI = QtGui.QDialog()
+        self.modelDoc = App.ActiveDocument
+        try:
+            self.model = self.modelDoc.Assembly
+            print("ASM4> BOM of the Assembly 4 Model")
+        except:
+            try:
+                self.model = self.modelDoc.Model
+                print("ASM4> BOM of the legacy Assembly 4 Model")
+            except:
+                print("ASM4> BOM might not work with this file")
+
+        doc = App.ActiveDocument
+        self.check_interferences()
+        doc.recompute()
+
+    def make_simple_part_copy(self, doc, obj):
+        __shape = Part.getShape(obj, '', needSubElement=False, refine=False)
+        doc.addObject('Part::Feature', obj.Label).Shape = __shape
+        doc.ActiveObject.Label = obj.Label
+        new_obj = doc.ActiveObject
+        new_obj.ViewObject.ShapeColor = getattr(obj.getLinkedObject(True).ViewObject, 'ShapeColor', new_obj.ViewObject.ShapeColor)
+        new_obj.ViewObject.LineColor  = getattr(obj.getLinkedObject(True).ViewObject, 'LineColor',  new_obj.ViewObject.LineColor)
+        new_obj.ViewObject.PointColor = getattr(obj.getLinkedObject(True).ViewObject, 'PointColor', new_obj.ViewObject.PointColor)
+        doc.recompute()
+        return new_obj
+
+    def make_intersection(self, doc, obj1, obj2, count):
+        obj = doc.addObject("Part::MultiCommon", "Common")
+        obj.Shapes = [obj1, obj2]
+        obj1.Visibility = False
+        obj2.Visibility = False
+        obj.Label = "Common {} - {} - {}".format(str(count), obj1.Label, obj2.Label)
+        obj.ViewObject.DisplayMode = getattr(obj1.getLinkedObject(True).ViewObject, 'DisplayMode', obj.ViewObject.DisplayMode)
+        obj.ViewObject.ShapeColor = (255, 170, 0) # YELLOW
+        obj.ViewObject.Transparency = 0
+        obj.ViewObject.DisplayMode = "Shaded"
+        doc.recompute()
+        obj.Label2 = "Volume = {:4f}".format(obj.Shape.Volume)
+        return obj
+
+    def remove_empty_common(self, obj):
+        try:
+            if obj.Shape:
+                try:
+                    if obj.Shape.Volume > 0.0:
+                        print("{} | Collision detected".format(obj.Label))
+                        return False
+                    else:
+                        print("{} | Touching faces (REMOVING)".format(obj.Label))
+                        for shape in obj.Shapes:
+                            doc.removeObject(shape.Name)
+                        doc.removeObject(obj.Name)
+                        return True
+                except:
+                    for shape in obj.Shapes:
+                        doc.removeObject(shape.Name)
+                    doc.removeObject(obj.Name)
+                    return True
+        except:
+            for shape in common.Shapes:
+                doc.removeObject(shape.Name)
+            doc.removeObject(common.Name)
+            return True
+
+    def remove_interference_folder(self):
+
+        doc = App.ActiveDocument
+
+        try:
+            model = doc.Model
+            model.Visibility = True
+        except:
+            model = doc.Assembly
+            model.Visibility = True
+
+        doc.Parts.Visibility = True
+        for obj in doc.Parts.Group:
+            try:
+                obj.Visibility = False
+            except: 
+                pass
+
+        # Remove existing folder and its contents
+        try:
+            existing_folder = doc.getObject("Interference")
+            for obj in existing_folder.Group:
+
+                if obj.TypeId == 'App::Part':
+                    obj.removeObjectsFromDocument() # Remove Part's content
+                    doc.removeObject(obj.Name) # Remove the Part
+
+                elif obj.TypeId == 'App::DocumentObjectGroup':
+
+                    for obj2 in obj.Group:
+
+                        if obj2.TypeId == "Part::MultiCommon":
+                            for shape in obj2.Shapes:
+                                doc.removeObject(shape.Name) # Remove Common's Parts
+                            doc.removeObject(obj2.Name) # Remove Common
+
+                    doc.removeObject(obj.Name) # Remove Group
+
+            doc.removeObject(existing_folder.Name) # Remove Interference folder
+            doc.recompute()
+        except:
+            pass
+
+    def check_interferences(self, ilim=0, jlim=0):
+
+        doc = App.ActiveDocument
+        model = doc.Model
+
+        if model == None:
+            print("Assembly is missing")
+            return
+
+        self.remove_interference_folder()
+
+        try:
+            model = doc.Model
+            model.Visibility = False
+        except:
+            model = doc.Assembly
+            model.Visibility = False
+
+        doc.Parts.Visibility = True
+        for obj in doc.Parts.Group:
+            try:
+                obj.Visibility = False
+            except: 
+                pass
+
+        # Create the Interference folder
+        intersections_folder = doc.addObject('App::DocumentObjectGroup', 'Interference')
+        doc.Tip = intersections_folder
+        intersections_folder.Label = 'Interference'
+
+        model_part = doc.addObject('App::Part', 'Assembly')
+        doc.Tip = model_part
+        model_part.Label = 'Assembly'
+        intersections_folder.addObject(model_part)
+
+        # Create the Common folder inside of the Interference
+        common_folder = doc.addObject('App::DocumentObjectGroup', 'Common')
+        doc.Tip = common_folder
+        common_folder.Label = 'Common'
+        intersections_folder.addObject(common_folder)
+
+        doc.recompute()
+
+        i = 0
+        c = 1
+
+        checked_dict = dict()
+
+        for obj1 in model.Group:
+
+            if obj1.Visibility == True and obj1.TypeId == 'App::Link':
+            # if obj1.Visibility == True and
+            #     ((obj1.TypeId == 'Part::FeaturePython' and (obj1.Content.find("FastenersCmd") or (obj1.Content.find("PCBStandoff")) > -1)) or
+            #     (obj1.TypeId == 'App::Link')):
+
+                print("\n==============================================================")
+                i = i + 1
+                j = 0
+
+                for obj2 in model.Group:
+
+                    if obj2 != obj1:
+
+                        if obj2.Visibility == True and obj2.TypeId == 'App::Link':
+                        # if obj2.Visibility == True and
+                        #     ((obj2.TypeId == 'Part::FeaturePython' and (obj2.Content.find("FastenersCmd") or (obj2.Content.find("PCBStandoff")) > -1)) or
+                        #     (obj2.TypeId == 'App::Link')):
+
+                            j = j + 1
+                            if not jlim == 0 and j >= jlim:
+                                break
+
+                            print(">> {} ({}, {}) {}, {}".format(c, i, j, obj1.Label, obj2.Label))
+
+                            if not obj1.Label in checked_dict:
+
+                                    c = c + 1
+
+                                    # print("1st time {} being used, checking intersection (1)...".format(obj1.Label))
+
+                                    obj1_list = []
+                                    obj1_list.append(obj2.Label)
+                                    checked_dict[obj1.Label] = obj1_list
+
+                                    obj1_model_cpy = self.make_simple_part_copy(doc, obj1)
+                                    model_part.addObject(obj1_model_cpy)
+                                    obj1_model_cpy.Visibility = True
+                                    obj1_model_cpy.ViewObject.Transparency = 92
+                                    obj1_model_cpy.ViewObject.ShapeColor = (90, 90, 90)
+                                    obj1_model_cpy.ViewObject.DisplayMode = "Shaded"
+
+                                    # Also add the complement to the dictionary for complitude
+                                    if not obj2.Label in checked_dict:
+                                        obj2_list = []
+                                        obj2_list.append(obj1.Label)
+                                        checked_dict[obj2.Label] = obj2_list
+
+                                        obj2_model_cpy = self.make_simple_part_copy(doc, obj2)
+                                        model_part.addObject(obj2_model_cpy)
+                                        obj2_model_cpy.Visibility = True
+                                        obj2_model_cpy.ViewObject.Transparency = 92
+                                        obj2_model_cpy.ViewObject.ShapeColor = (90, 90, 90)
+                                        obj2_model_cpy.ViewObject.DisplayMode = "Shaded"
+
+
+                                    obj1_cpy = self.make_simple_part_copy(doc, obj1)
+                                    obj2_cpy = self.make_simple_part_copy(doc, obj2)
+                                    common = self.make_intersection(doc, obj1_cpy, obj2_cpy, c)
+                                    common_folder.addObject(common)
+
+                            else:
+
+                                if not obj2.Label in checked_dict[obj1.Label]:
+
+                                    c = c + 1
+
+                                    # print("Obj {} already used, checking intersection (2)...".format(obj1.Label))
+
+                                    obj1_list = checked_dict[obj1.Label]
+                                    obj1_list.append(obj2.Label)
+                                    checked_dict[obj1.Label] = obj1_list
+
+                                    if obj2.Label in checked_dict:
+                                        obj2_list = checked_dict[obj2.Label]
+                                        obj2_list.append(obj1.Label)
+                                        checked_dict[obj2.Label] = obj2_list
+
+                                    obj1_cpy = self.make_simple_part_copy(doc, obj1)
+                                    obj2_cpy = self.make_simple_part_copy(doc, obj2)
+                                    common = self.make_intersection(doc, obj1_cpy, obj2_cpy, c)
+                                    common_folder.addObject(common)
+
+                                # else:
+                                    # print("Intersection already checked!")
+
+                            Gui.updateGui()
+
+                Gui.updateGui()
+
+            if not ilim == 0 and i >= ilim:
+                break
+
+
+        # Update intersections (remove empty and change colors)
+        print("\n>> PROCESSING INTERSECTIONS:")
+        for obj in common_folder.Group:
+            if obj.TypeId == "Part::MultiCommon":
+                if not self.remove_empty_common(obj):
+                    obj.ViewObject.Transparency = 60
+                    r = rnd.random()
+                    g = rnd.random()
+                    b = rnd.random()
+                    obj.ViewObject.ShapeColor = (r, g, b)
+
+            Gui.updateGui()
+
+        doc.recompute()
+
+        # if obj1.TypeId == 'App::DocumentObjectGroup':
+        #     for objname in obj1.getSubObjects():
+        #         subobj = obj.Document.getObject(objname[0:-1])
+
+
+        # print("\n>> CHECKED OBJECTS:")
+        # for a, key in enumerate(checked_dict):
+        #     print("  ", a+1, key)
+        #     for b, item in enumerate(checked_dict[key]):
+        #         print("    ", b+1, item)
+
+        print("\n>> USED PARTS:")
+        for p, part in enumerate(checked_dict):
+            print("  ", p+1, part)
+        print("")
+
+
+class removeInterference:
+
+    def __init__(self):
+        super(removeInterference, self).__init__()
+
+    def GetResources(self):
+
+        menutext = "Remove Interference Checks"
+        tooltip  = "Remove the generated interference checks, restoring visibilty of the Assembly."
+        iconFile = os.path.join(Asm4.iconPath, 'Asm4_Interference_Cleanup.svg')
+
+        return {
+            "MenuText": menutext,
+            "ToolTip": tooltip,
+            "Pixmap": iconFile
+        }
+
+    def IsActive(self):
+        if Asm4.getAssembly() is None:
+            return False
+        else:
+            return True
+
+    def Activated(self):
+        self.remove_interference_folder()
+
+    def remove_interference_folder(self):
+
+        doc = App.ActiveDocument
+
+        try:
+            model = doc.Model
+            model.Visibility = True
+        except:
+            model = doc.Assembly
+            model.Visibility = True
+
+        doc.Parts.Visibility = True
+        for obj in doc.Parts.Group:
+            try:
+                obj.Visibility = False
+            except: 
+                pass
+
+        # Remove existing folder and its contents
+        try:
+            existing_folder = doc.getObject("Interference")
+            for obj in existing_folder.Group:
+
+                if obj.TypeId == 'App::Part':
+                    obj.removeObjectsFromDocument() # Remove Part's content
+                    doc.removeObject(obj.Name) # Remove the Part
+
+                elif obj.TypeId == 'App::DocumentObjectGroup':
+
+                    for obj2 in obj.Group:
+
+                        if obj2.TypeId == "Part::MultiCommon":
+                            for shape in obj2.Shapes:
+                                doc.removeObject(shape.Name) # Remove Common's Parts
+                            doc.removeObject(obj2.Name) # Remove Common
+
+                    doc.removeObject(obj.Name) # Remove Group
+
+            doc.removeObject(existing_folder.Name) # Remove Interference folder
+            doc.recompute()
+        except:
+            pass
+
+
+# Add the command in the workbench
+Gui.addCommand('Asm4_checkInterference',  checkInterference())
+Gui.addCommand('Asm4_removeInterference', removeInterference())


### PR DESCRIPTION
Hi Zolko, this PR is my initial attempt to add my interference check script to this workbench.
The code should be improved of course, and also the idea can get matured by discussing it here.

In short, this adds 2 toolbar icons to Checks Interferences and also Removes the generated Interference check objects. The icons and the place on the toolbar should be also improved later, I just added them to have something to start the discussion.
![image](https://user-images.githubusercontent.com/1277920/233762914-9805ce3b-ed86-4ff2-b7ab-8ef1e60aee0c.png)

The idea is quite simple. The interference check iterates through all objects inside the Model/Assembly and performs a `Part > Common` operation with each part against the others. The resulting object that has a volume equal to zero, does not have parts interfering and is excluded. The objects that have a volume greater than zero are interfering with each other. Then this "common" object is highlighted. The name of each common object is related to both parts that conflict, so it is easy to locate them to fix them. 

Every time the user hits the toolbar button to check the Interference folder is recreated. The operation may take some time.

The second button removes the Interference folder easily since just deleting it by hitting the Del key does not remove all objects from inside of this folder by default. It also restores the visibility of the Model/Assembly. It could also restore the initial visibility of everything but this is not implemented yet.

A lot of cleanup and improvement of the code can happen since I quickly ported my initial script to this workbench. 

The Interference folder has also a copy of the Assembly with different opacity so it is easier to locate visually the interferences where they occur. 

There are also objects missing from the check (maybe fasteners, and others) that would be good to have included.

Here is an example (a caliper with an object next to its end)
![image](https://user-images.githubusercontent.com/1277920/233763490-f3c78697-b97c-4702-a580-8078a1940f3d.png)

The interferences are highlighted here, after processing... 
![image](https://user-images.githubusercontent.com/1277920/233763468-ff61b11e-ba65-4981-b7c5-c52ace8885fe.png)

The object tree with the objects created
![image](https://user-images.githubusercontent.com/1277920/233763698-f1800617-c072-4072-b2d0-047eb17b2e43.png)


