### PR TITLE
Fix state serialization on FreeCAD >= 0.22

### DIFF
--- a/Asm4_objects.py
+++ b/Asm4_objects.py
@@ -20,6 +20,8 @@ from FreeCAD import Console as FCC
 import Asm4_libs as Asm4
 
 
+FREECAD_0_22 = (int(App.Version()[0]), int(App.Version()[1])) >= (0, 22)
+
 
 """
     +-----------------------------------------------+
@@ -51,12 +53,20 @@ class VariantLink( object ):
     def __init__(self):
         FCC.PrintMessage('Initialising ...\n')
         self.Object = None
-    
-    def __getstate__(self):
-        return
 
-    def __setstate__(self,_state):
-        return
+
+    if FREECAD_0_22:
+        def loads(self, state):
+            return None
+
+        def dumps(self):
+            return None
+    else: 
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, _state):
+            return None
     
     # new Python API for overriding C++ view provider of the binding object
     def getViewProviderName(self,_obj):
@@ -237,11 +247,18 @@ class ViewProviderVariant(object):
             iconPath = os.path.join( Asm4.iconPath, 'Variant_Link.svg' )
         return iconPath
                 
-    def __getstate__(self):
-        return None
+    if FREECAD_0_22:
+        def loads(self, state):
+            return None
 
-    def __setstate__(self, _state):
-        return None
+        def dumps(self):
+            return None
+    else: 
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, _state):
+            return None
     
 
 
@@ -260,12 +277,19 @@ class LinkArray( object ):
     def __init__(self):
         self.Object = None
     
-    def __getstate__(self):
-        return
+    if FREECAD_0_22:
+        def loads(self, state):
+            return None
 
-    def __setstate__(self,_state):
-        return
-    
+        def dumps(self):
+            return None
+    else: 
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, _state):
+            return None
+   
     # new Python API for overriding C++ view provider of the binding object
     def getViewProviderName(self,_obj):
         return 'Gui::ViewProviderLinkPython'
@@ -355,12 +379,19 @@ class ViewProviderArray(object):
                 iconFile = os.path.join( Asm4.iconPath, 'Asm4_ExpressionArray.svg')
         if iconFile:
             return iconFile
-                
-    def __getstate__(self):
-        return None
 
-    def __setstate__(self, _state):
-        return None
+    if FREECAD_0_22:
+        def loads(self, state):
+            return None
+
+        def dumps(self):
+            return None
+    else: 
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, _state):
+            return None
     
 
 


### PR DESCRIPTION
As of https://github.com/FreeCAD/FreeCAD/commit/83d4080fe8 FreeCAD (for compatibility with Python 3.11) has renamed the methods to loads and dumps. Using this workbench with the latest FreeCAD main branch surfaced this issue as I wasn't able to save my documents again.

I found the change https://github.com/fra589/CurvesWB/commit/3374dbb83ea2a09787819b1e153a5697f5e19ea7 in the CurvesWB and adopted it for this WB.