### PR TITLE
Discard unneeded int casts in getStandardButtons methods

### DIFF
--- a/Asm4_Measure.py
+++ b/Asm4_Measure.py
@@ -153,9 +153,7 @@ class MeasureUI():
 
     # standard FreeCAD Task panel buttons
     def getStandardButtons(self):
-        return int(   QtGui.QDialogButtonBox.Cancel
-                    | QtGui.QDialogButtonBox.Reset
-                    | QtGui.QDialogButtonBox.Ok )
+        return QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Reset | QtGui.QDialogButtonBox.Ok
 
     # OK button
     def accept(self):

--- a/configurationEngine.py
+++ b/configurationEngine.py
@@ -138,8 +138,8 @@ class openConfigurationsUI():
 
     # standard FreeCAD Task panel buttons
     def getStandardButtons(self):
-        # return int(QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Ok)
-        return int( QtGui.QDialogButtonBox.Close | QtGui.QDialogButtonBox.Apply )
+        # return QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Ok
+        return QtGui.QDialogButtonBox.Close | QtGui.QDialogButtonBox.Apply
 
     # OK = apply and close
     def accept(self):

--- a/infoPartCmd.py
+++ b/infoPartCmd.py
@@ -484,7 +484,7 @@ class infoPartUI():
         Gui.Control.closeDialog()
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Ok
 
     def reject(self):
         self.finish()
@@ -569,7 +569,7 @@ class infoPartConfUI():
         Gui.Control.closeDialog()
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Ok
 
     def reject(self):
         self.finish()

--- a/placeLinkUI.py
+++ b/placeLinkUI.py
@@ -228,9 +228,7 @@ class placeLinkUI():
 
     # standard FreeCAD Task panel buttons
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Cancel
-                   | QtGui.QDialogButtonBox.Ok
-                   | QtGui.QDialogButtonBox.Ignore)
+        return QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Ignore
 
 
     # OK

--- a/placePartUI.py
+++ b/placePartUI.py
@@ -121,8 +121,7 @@ class placePartUI():
 
     # standard FreeCAD Task panel buttons
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Cancel
-                   | QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Ok
 
     # OK
     def accept(self):


### PR DESCRIPTION
Because `QtWidgets.QDialogButtonBox.StandardButtons` are already converted into `int`s in FreeCAD's `Gui::TaskDialogPython::getStandardButtons`, such conversions in workbench code aren't needed. Also this fixes compatibility with PySide6.
