### PR TITLE
Creates LCS inside a body if features of the body are selected

### DIFF
--- a/newDatumCmd.py
+++ b/newDatumCmd.py
@@ -87,14 +87,11 @@ class newDatum:
             selectedObj = Gui.Selection.getSelection()[0]
             # ... and it's an App::Part or an datum object
             selType = selectedObj.TypeId
-
             if selType in self.containers or selType in Asm4.datumTypes or selType=='Sketcher::SketchObject':
                 return(selectedObj)
-
             # When the selected item is a feature of a Body, it returns the Body itself.
-            if selectedObj._Body.TypeId == 'PartDesign::Body':
+            elif obj.getParentGeoFeatureGroup().TypeId in Asm4.containerTypes:
                 return(selectedObj._Body)
-
         # or if nothing is selected ...
         elif Asm4.getAssembly():
             # ... but there is as assembly:

--- a/newDatumCmd.py
+++ b/newDatumCmd.py
@@ -87,9 +87,15 @@ class newDatum:
             selectedObj = Gui.Selection.getSelection()[0]
             # ... and it's an App::Part or an datum object
             selType = selectedObj.TypeId
+
             if selType in self.containers or selType in Asm4.datumTypes or selType=='Sketcher::SketchObject':
                 return(selectedObj)
-        # or of nothing is selected ...
+
+            # When the selected item is a feature of a Body, it returns the Body itself.
+            if selectedObj._Body.TypeId == 'PartDesign::Body':
+                return(selectedObj._Body)
+
+        # or if nothing is selected ...
         elif Asm4.getAssembly():
             # ... but there is as assembly:
             return Asm4.getAssembly()
@@ -124,7 +130,7 @@ class newDatum:
             parentContainer = Asm4.getAssembly()
         # something went wrong
         else:
-            Asm4.warningBox("I can't create a "+self.datumType+" with the current selections")
+            Asm4.warningBox("Can't create a "+self.datumType+" with the current selections")
             
         # check whether there is already a similar datum, and increment the instance number 
         # instanceNum = 1
@@ -160,27 +166,6 @@ class newDatum:
                 Gui.Selection.addSelection( App.ActiveDocument.Name, parentContainer.Name, createdDatum.Name+'.' )
 
                 Gui.runCommand('Part_EditAttachment')
-
-                self.waiting_until_Part_EditAttachment_finishes()
-
-                # Restore original selection...
-                Gui.Selection.clearSelection()
-                Gui.Selection.addSelection(App.ActiveDocument.Name, selectedObj.Name)
-
-
-    def waiting_until_Part_EditAttachment_finishes(self):
-        self.Part_EditAttachment_is_finished = True
-        timer = QtCore.QTimer()
-        timer.timeout.connect(self.check_if_Part_EditAttachment_finished)
-        timer.start(500)
-        while self.Part_EditAttachment_is_finished:
-            Gui.updateGui() # Refresh GUI
-        timer.stop()
-
-
-    def check_if_Part_EditAttachment_finished(self):
-        if Gui.Control.activeDialog() == False:
-            self.Part_EditAttachment_is_finished = False
 
 
 """

--- a/newDatumCmd.py
+++ b/newDatumCmd.py
@@ -154,11 +154,33 @@ class newDatum:
                     Gui.ActiveDocument.getObject(createdDatum.Name).ShapeColor = self.datumColor
                 if self.datumAlpha:
                     Gui.ActiveDocument.getObject(createdDatum.Name).Transparency = self.datumAlpha
+
                 # highlight the created datum object
                 Gui.Selection.clearSelection()
                 Gui.Selection.addSelection( App.ActiveDocument.Name, parentContainer.Name, createdDatum.Name+'.' )
+
                 Gui.runCommand('Part_EditAttachment')
 
+                self.waiting_until_Part_EditAttachment_finishes()
+
+                # Restore original selection...
+                Gui.Selection.clearSelection()
+                Gui.Selection.addSelection(App.ActiveDocument.Name, selectedObj.Name)
+
+
+    def waiting_until_Part_EditAttachment_finishes(self):
+        self.Part_EditAttachment_is_finished = True
+        timer = QtCore.QTimer()
+        timer.timeout.connect(self.check_if_Part_EditAttachment_finished)
+        timer.start(500)
+        while self.Part_EditAttachment_is_finished:
+            Gui.updateGui() # Refresh GUI
+        timer.stop()
+
+
+    def check_if_Part_EditAttachment_finished(self):
+        if Gui.Control.activeDialog() == False:
+            self.Part_EditAttachment_is_finished = False
 
 
 """

--- a/newDatumCmd.py
+++ b/newDatumCmd.py
@@ -90,8 +90,8 @@ class newDatum:
             if selType in self.containers or selType in Asm4.datumTypes or selType=='Sketcher::SketchObject':
                 return(selectedObj)
             # When the selected item is a feature of a Body, it returns the Body itself.
-            elif obj.getParentGeoFeatureGroup().TypeId in Asm4.containerTypes:
-                return(selectedObj._Body)
+            elif selectedObj.getParentGeoFeatureGroup().TypeId in Asm4.containerTypes:
+                return(selectedObj.getParentGeoFeatureGroup())
         # or if nothing is selected ...
         elif Asm4.getAssembly():
             # ... but there is as assembly:


### PR DESCRIPTION
This is outaded.


~Hi, @Zolko-123 this PR improves the Create Datum process.~

~After creating a new Datum, the selection (selected object) is changed, making the process of creating multiple datums a pain.~

~With this fix, it is possible to create multiple Datums on the same object in series since it preserves the original selection.~

~Here is a video of the process after the fix where the selection returns to the Body after each Datum is created.~

https://github.com/user-attachments/assets/35fa55eb-94fd-40e1-adba-4aeb62055baf