### PR TITLE
Click on 3d model to edit placement

### DIFF
--- a/Asm4_libs.py
+++ b/Asm4_libs.py
@@ -682,6 +682,19 @@ def getSelectedContainer():
     return retval
 
 
+def getDirectParent():
+    # including links, specially usefull for when selecting ojects by clicking on 3d models
+    sels = Gui.Selection.getSelectionEx("", 0)
+    sel = sels[0]
+    sub = sel.SubElementNames[0] if sel.SubElementNames else ""
+    obj = sel.Object.getSubObject(sub, 1)
+    if obj == sel.Object:
+        direct_parent = None
+    else:
+        direct_parent = sel.Object.getSubObject(sub.rpartition(obj.Name)[0], 1)
+    return direct_parent
+
+
 # returns the selected App::Link
 def getSelectedLink():
     retval = None


### PR DESCRIPTION
Hi @Zolko-123 

Similar to my last PR where I improved the LCS creation sequentially, here I made it possible to edit the placement by clicking the 3d model instead of selecting the model in the Object tree.

I tested this on `0.21` and `1.1-dev`

I am attaching this sample file so you can easily verify if it works. 
[immediate_parent_link_selection.FCStd.zip](https://github.com/user-attachments/files/18791504/immediate_parent_link_selection.FCStd.zip)

The test is simple, click on each object, and check if it enables the `Asm4_placeLink` icon and if its function works as expected.

There are 5 different objects only Links_1, Link_2, and Link_3 should enable the feature.
![image](https://github.com/user-attachments/assets/f888ff33-6024-4a4d-96e4-4c923646c9f9)

This is my first attempt after working on this for some time, so things can be improved to make it look more like the Asm4.
