### PR TITLE
Improve PlaceLink with Equations for Translation, and custom step for Rotation

### DIFF
--- a/insertLinkCmd.py
+++ b/insertLinkCmd.py
@@ -316,6 +316,11 @@ class insertLink():
     |     defines the UI, only static elements      |
     +-----------------------------------------------+
     """
+
+    def mouseDoubleClickEvent(self, event):
+        self.onCreateLink()
+        # print('dblclick:', event.text())
+
     def drawUI(self):
         # Our main window is a QDialog
         # make this dialog stay above the others, always visible
@@ -340,6 +345,10 @@ class insertLink():
         # Insert Link button
         self.insertButton = QtGui.QPushButton('Insert', self.UI)
         self.insertButton.setDefault(True)
+
+        # self.connect(self.partList, QtCore.SIGNAL("itemDoubleClicked(QListWidgetItem *)"), self.showItem)
+        self.partList.itemDoubleClicked.connect(self.mouseDoubleClickEvent)
+
 
         # Place the widgets with layouts
         self.mainLayout = QtGui.QVBoxLayout(self.UI)

--- a/placeLinkUI.py
+++ b/placeLinkUI.py
@@ -212,8 +212,7 @@ class placeLinkUI():
                     parent_index += 1
         if not parent_found:
             parent_index = 0
-        self.parentList.setCurrentIndex(parent_index) # why is it not working?
-        self.parentList.setCurrentIndex(1)
+        self.parentList.setCurrentIndex(parent_index)
         # this should have triggered Asm4.getPartLCS() to fill the LCS list
 
         # find the old attachment Datum in the list of the Datums in the linked part...


### PR DESCRIPTION
Preview of the options.
This PR should have been added some time ago, now I took the opportunity to push this. 

Translations can be performed with equations.
Rotations can be customized to have a custom step.
And can go in both directions, it is also possible to rest the rotation on each axis.
By default, it is set to steps of 45, instead of the current 90.

![image](https://github.com/user-attachments/assets/39e3a508-74a3-49be-997b-acbf26138e56)

Here in this file `insertLinkCmd.py` I am enabling double click on object names to place a link.